### PR TITLE
Issue 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ### Fixed
 
-- Fixed #3 where exception no longer is thrown when the property changed event for `IModalDialogViewModel.DialogResult` is sent twice
+- Fixed [Issue #3](https://github.com/FantasticFiasco/mvvm-dialogs/issues/3) where exception no longer is thrown when the property changed event for `IModalDialogViewModel.DialogResult` is sent twice
 
 ## [1.1.3] - 2015-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed #3 where exception no longer is thrown when the property changed event for `IModalDialogViewModel.DialogResult` is sent twice
+
 ## [1.1.3] - 2015-07-07
 
 ### Fixed

--- a/src/DemoApplicationTest/DemoApplicationTest.csproj
+++ b/src/DemoApplicationTest/DemoApplicationTest.csproj
@@ -107,7 +107,9 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/MvvmDialogs.sln
+++ b/src/MvvmDialogs.sln
@@ -41,7 +41,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Build", ".Build", "{134A50
 		..\BuildNuGet.bat = ..\BuildNuGet.bat
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub publication", "GitHub publication", "{76759856-59C1-41D8-9024-B899606B1EF6}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Documentation", ".Documentation", "{76759856-59C1-41D8-9024-B899606B1EF6}"
 	ProjectSection(SolutionItems) = preProject
 		..\CHANGELOG.md = ..\CHANGELOG.md
 		..\README.md = ..\README.md

--- a/src/MvvmDialogs/DialogService.cs
+++ b/src/MvvmDialogs/DialogService.cs
@@ -314,7 +314,7 @@ namespace MvvmDialogs
         {
             PropertyChangedEventHandler handler = (sender, e) =>
             {
-                if (e.PropertyName == DialogResultPropertyName)
+                if (e.PropertyName == DialogResultPropertyName && dialog.DialogResult != viewModel.DialogResult)
                 {
                     dialog.DialogResult = viewModel.DialogResult;
                 }

--- a/src/MvvmDialogsTest/MvvmDialogsTest.csproj
+++ b/src/MvvmDialogsTest/MvvmDialogsTest.csproj
@@ -80,6 +80,9 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
Fixes #3.

Solved by adding a check for dialog result being different before setting it. This prevents an exception being thrown when consumers sends the `DialogResult` property changed event twice.