### PR TITLE
Logger.Writer.set should throw when value is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ## Unreleased
 
+### :syringe: Fixed
+
+- `Logger.Writer` does not throw exception when being set to `null` (contribution by [@MathewSachin](https://github.com/MathewSachin))
+
 ## 5.2.1 - 2018-10-30
 
 ### :syringe: Fixed

--- a/src/net/Logging/Logger.cs
+++ b/src/net/Logging/Logger.cs
@@ -29,7 +29,7 @@ namespace MvvmDialogs.Logging
             get => writer;
             set
             {
-                if (writer == null) throw new ArgumentNullException(nameof(value));
+                if (value == null) throw new ArgumentNullException(nameof(value));
 
                 writer = value;
             }


### PR DESCRIPTION
I guess it was just a typo, but currently once `Logger.Writer` has been set to `null`, it cannot be changed again.
The expected behaviour is to `throw` when value is `null`.