### PR TITLE
IDialogService.Close manage a boolean return type such as IDialogServ…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ## Unreleased
 
+### :syringe: Changed
+
+- [#116](https://github.com/FantasticFiasco/mvvm-dialogs/issues/116) [BREAKING CHANGE] `IDialogService.Close` returns `false` instead of throwing an exception when failing to close a dialog. This behavior mimics the behavior of `IDialogService.Activate`.
+
 ## 7.1.0 - 2020-06-07
 
 ### :zap: Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ### :syringe: Changed
 
-- [#116](https://github.com/FantasticFiasco/mvvm-dialogs/issues/116) [BREAKING CHANGE] `IDialogService.Close` returns `false` instead of throwing an exception when failing to close a dialog. This behavior mimics the behavior of `IDialogService.Activate`.
+- [#116](https://github.com/FantasticFiasco/mvvm-dialogs/issues/116) [BREAKING CHANGE] `IDialogService.Close` returns `false` instead of throwing an exception when failing to close a dialog. This behavior aligns with the behavior of `IDialogService.Activate`.
 
 ## 7.1.0 - 2020-06-07
 

--- a/src/net/DialogService.cs
+++ b/src/net/DialogService.cs
@@ -168,15 +168,20 @@ namespace MvvmDialogs
 
             foreach (Window? window in Application.Current.Windows)
             {
-                if (window == null)
+                if (window == null || !viewModel.Equals(window.DataContext))
                 {
                     continue;
                 }
 
-                if (viewModel.Equals(window.DataContext))
+                try
                 {
                     window.Close();
                     return true;
+                }
+                catch (Exception e)
+                {
+                    Logger.Write($"Failed to close dialog: {e}");
+                    break;
                 }
             }
 

--- a/src/net/DialogService.cs
+++ b/src/net/DialogService.cs
@@ -162,7 +162,7 @@ namespace MvvmDialogs
         }
 
         /// <inheritdoc />
-        public void Close(INotifyPropertyChanged viewModel)
+        public bool Close(INotifyPropertyChanged viewModel)
         {
             if (viewModel == null) throw new ArgumentNullException(nameof(viewModel));
 
@@ -176,11 +176,11 @@ namespace MvvmDialogs
                 if (viewModel.Equals(window.DataContext))
                 {
                     window.Close();
-                    return;
+                    return true;
                 }
             }
 
-            throw new DialogNotFoundException();
+            return false;
         }
 
         /// <inheritdoc />

--- a/src/net/IDialogService.cs
+++ b/src/net/IDialogService.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Windows;
 using MvvmDialogs.FrameworkDialogs.FolderBrowser;
 using MvvmDialogs.FrameworkDialogs.MessageBox;
@@ -134,10 +135,10 @@ namespace MvvmDialogs
         /// <see cref="Show{T}"/> or <see cref="ShowCustom{T}"/>.
         /// </summary>
         /// <param name="viewModel">The view model of the dialog to close.</param>
-        /// <exception cref="DialogNotFoundException">
-        /// No dialog is found with specified view model as data context.
-        /// </exception>
-        void Close(INotifyPropertyChanged viewModel);
+        /// <returns>
+        /// true if the <see cref="Window"/> was successfully found; otherwise, false./>
+        /// </returns>
+        bool Close(INotifyPropertyChanged viewModel);
 
         /// <summary>
         /// Displays a message box that has a message, title bar caption, button, and icon; and

--- a/src/net/IDialogService.cs
+++ b/src/net/IDialogService.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Windows;
 using MvvmDialogs.FrameworkDialogs.FolderBrowser;
 using MvvmDialogs.FrameworkDialogs.MessageBox;
@@ -136,7 +135,7 @@ namespace MvvmDialogs
         /// </summary>
         /// <param name="viewModel">The view model of the dialog to close.</param>
         /// <returns>
-        /// true if the <see cref="Window"/> was successfully found; otherwise, false./>
+        /// true if the <see cref="Window"/> was successfully closed; otherwise, false.
         /// </returns>
         bool Close(INotifyPropertyChanged viewModel);
 


### PR DESCRIPTION
…ice.Activate method.

# Description
In case Show or ShowModal are based on certain logic, you cannot know if the window is modal or not. If you also need to close the window from its ViewModel, you can call .Close(this) without worrying about possible exceptions.
To check if window has been found and correctly closed, you can test the boolean result 

# Checklist

- [ ] I have squashed my commits into a single one with a message that aligns with the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
