### PR TITLE
Fix memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ NOTE: Features with breaking changes are found on branch [releases/v8](https://g
 ### :syringe: Fixed
 
 - Specify dependency groups in nuspec for each supported framework version
+- [#122](https://github.com/FantasticFiasco/mvvm-dialogs/issues/122) Fix memory leak where `Window.Closed` events never where un-registered (discovered by [@peter-durrant](https://github.com/peter-durrant))
 
 ## 7.1.0 - 2020-06-07
 

--- a/src/net/DialogServiceViews.cs
+++ b/src/net/DialogServiceViews.cs
@@ -109,7 +109,10 @@ namespace MvvmDialogs
 
             PruneInternalViews();
 
-            // Register for owner window closing, since we then should unregister view reference
+            // Register for owner window closing to cleanup views connected to this window, but
+            // only register for the event once, thus the un-registration of any prior
+            // registrations.
+            owner.Closed -= OwnerClosed;
             owner.Closed += OwnerClosed;
 
             Logger.Write($"Register view {view.Id}");


### PR DESCRIPTION
A memory leak was found by @peter-durrant in #122 where event registrations never was unregistered, thus causing a memory leak.