### PR TITLE
Update net-core/Demo.CustomFolderBrowserDialog to use Ookii.Dialogs...

### DIFF
--- a/samples/net-core/Demo.CustomFolderBrowserDialog/CustomFolderBrowserDialog.cs
+++ b/samples/net-core/Demo.CustomFolderBrowserDialog/CustomFolderBrowserDialog.cs
@@ -1,18 +1,15 @@
 ﻿using System;
 using System.Windows;
-using System.Windows.Forms;
 using MvvmDialogs.FrameworkDialogs;
 using MvvmDialogs.FrameworkDialogs.FolderBrowser;
+using Ookii.Dialogs.Wpf;
 
 namespace Demo.CustomFolderBrowserDialog
 {
-    /// <remarks>
-    /// This sample differs from the .NET Framework equivalent. The reason for that is that the
-    /// dependency Ookii.Dialogs.Wpf currently doesn't support .NET Core 3.
-    /// </remarks>
     public class CustomFolderBrowserDialog : IFrameworkDialog
     {
         private readonly FolderBrowserDialogSettings settings;
+        private readonly VistaFolderBrowserDialog folderBrowserDialog;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FolderBrowserDialogWrapper"/> class.
@@ -21,6 +18,13 @@ namespace Demo.CustomFolderBrowserDialog
         public CustomFolderBrowserDialog(FolderBrowserDialogSettings settings)
         {
             this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+            folderBrowserDialog = new VistaFolderBrowserDialog
+            {
+                Description = settings.Description,
+                SelectedPath = settings.SelectedPath,
+                ShowNewFolderButton = settings.ShowNewFolderButton
+            };
         }
 
         /// <summary>
@@ -36,33 +40,12 @@ namespace Demo.CustomFolderBrowserDialog
         {
             if (owner == null) throw new ArgumentNullException(nameof(owner));
 
-            using (var dialog = new FolderBrowserDialog())
-            {
-                // Update dialog
-                dialog.Description = settings.Description;
-                dialog.SelectedPath = settings.SelectedPath;
-                dialog.ShowNewFolderButton = settings.ShowNewFolderButton;
+            var result = folderBrowserDialog.ShowDialog(owner);
 
-                // Show dialog
-                var result = dialog.ShowDialog(new Win32Window(owner));
+            // Update settings
+            settings.SelectedPath = folderBrowserDialog.SelectedPath;
 
-                // Update settings
-                settings.SelectedPath = dialog.SelectedPath;
-
-                switch (result)
-                {
-                    case DialogResult.OK:
-                    case DialogResult.Yes:
-                        return true;
-
-                    case DialogResult.No:
-                    case DialogResult.Abort:
-                        return false;
-
-                    default:
-                        return null;
-                }
-            }
+            return result;
         }
     }
 }

--- a/samples/net-core/Demo.CustomFolderBrowserDialog/Demo.CustomFolderBrowserDialog.Core.csproj
+++ b/samples/net-core/Demo.CustomFolderBrowserDialog/Demo.CustomFolderBrowserDialog.Core.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CustomFolderBrowserDialog</RootNamespace>
     <AssemblyName>Demo.CustomFolderBrowserDialog</AssemblyName>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="MvvmLightLibsStd10" Version="5.4.1.1" />
+    <PackageReference Include="Ookii.Dialogs.Wpf" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/net-core/Demo.CustomFolderBrowserDialog/app.manifest
+++ b/samples/net-core/Demo.CustomFolderBrowserDialog/app.manifest
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+</assembly>


### PR DESCRIPTION
... now that Ookii.Dialogs targets .NET Core 3.1 and .NET 5.

### net-core/Demo.CustomFolderBrowserDialog

- The `app.manifest` with the reference to `Microsoft.Windows.Common-Controls` is a new requirement for .NET Core apps using Ookii Dialogs ([more details here](https://github.com/augustoproiete-repros/repro-wpf-net5-comctl32-entrypointnotfoundexception))

- PR #136 already covers updating Ookii.Dialogs in the corresponding .NET Framework project