### PR TITLE
Update net-core/Demo.CustomMessageBox to use Ookii.Dialogs...

### DIFF
--- a/samples/net-core/Demo.CustomMessageBox/CustomMessageBox.cs
+++ b/samples/net-core/Demo.CustomMessageBox/CustomMessageBox.cs
@@ -1,16 +1,14 @@
 ﻿using System;
 using System.Windows;
 using MvvmDialogs.FrameworkDialogs.MessageBox;
+using Ookii.Dialogs.Wpf;
 
 namespace Demo.CustomMessageBox
 {
-    /// <remarks>
-    /// This sample differs from the .NET Framework equivalent. The reason for that is that the
-    /// dependency Ookii.Dialogs.Wpf currently doesn't support .NET Core 3.
-    /// </remarks>
     public class CustomMessageBox : IMessageBox
     {
         private readonly MessageBoxSettings settings;
+        private readonly TaskDialog messageBox;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomMessageBox"/> class.
@@ -19,6 +17,15 @@ namespace Demo.CustomMessageBox
         public CustomMessageBox(MessageBoxSettings settings)
         {
             this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+            messageBox = new TaskDialog
+            {
+                Content = settings.MessageBoxText
+            };
+
+            SetUpTitle();
+            SetUpButtons();
+            SetUpIcon();
         }
 
         /// <summary>
@@ -35,13 +42,84 @@ namespace Demo.CustomMessageBox
         {
             if (owner == null) throw new ArgumentNullException(nameof(owner));
 
-            return MessageBox.Show(
-                owner,
-                settings.MessageBoxText,
-                settings.Caption,
-                settings.Button,
-                settings.Icon,
-                settings.DefaultResult);
+            var result = messageBox.ShowDialog(owner);
+            return ToMessageBoxResult(result);
+        }
+
+        private void SetUpTitle()
+        {
+            messageBox.WindowTitle = string.IsNullOrEmpty(settings.Caption) ?
+                " " :
+                settings.Caption;
+        }
+
+        private void SetUpButtons()
+        {
+            switch (settings.Button)
+            {
+                case MessageBoxButton.OKCancel:
+                    messageBox.Buttons.Add(new TaskDialogButton(ButtonType.Ok));
+                    messageBox.Buttons.Add(new TaskDialogButton(ButtonType.Cancel));
+                    break;
+
+                case MessageBoxButton.YesNo:
+                    messageBox.Buttons.Add(new TaskDialogButton(ButtonType.Yes));
+                    messageBox.Buttons.Add(new TaskDialogButton(ButtonType.No));
+                    break;
+
+                case MessageBoxButton.YesNoCancel:
+                    messageBox.Buttons.Add(new TaskDialogButton(ButtonType.Yes));
+                    messageBox.Buttons.Add(new TaskDialogButton(ButtonType.No));
+                    messageBox.Buttons.Add(new TaskDialogButton(ButtonType.Cancel));
+                    break;
+
+                default:
+                    messageBox.Buttons.Add(new TaskDialogButton(ButtonType.Ok));
+                    break;
+            }
+        }
+
+        private void SetUpIcon()
+        {
+            switch (settings.Icon)
+            {
+                case MessageBoxImage.Error:
+                    messageBox.MainIcon = TaskDialogIcon.Error;
+                    break;
+
+                case MessageBoxImage.Information:
+                    messageBox.MainIcon = TaskDialogIcon.Information;
+                    break;
+
+                case MessageBoxImage.Warning:
+                    messageBox.MainIcon = TaskDialogIcon.Warning;
+                    break;
+
+                default:
+                    messageBox.MainIcon = TaskDialogIcon.Custom;
+                    break;
+            }
+        }
+
+        private static MessageBoxResult ToMessageBoxResult(TaskDialogButton button)
+        {
+            switch (button.ButtonType)
+            {
+                case ButtonType.Cancel:
+                    return MessageBoxResult.Cancel;
+
+                case ButtonType.No:
+                    return MessageBoxResult.No;
+
+                case ButtonType.Ok:
+                    return MessageBoxResult.OK;
+
+                case ButtonType.Yes:
+                    return MessageBoxResult.Yes;
+
+                default:
+                    return MessageBoxResult.None;
+            }
         }
     }
 }

--- a/samples/net-core/Demo.CustomMessageBox/Demo.CustomMessageBox.Core.csproj
+++ b/samples/net-core/Demo.CustomMessageBox/Demo.CustomMessageBox.Core.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CustomMessageBox</RootNamespace>
     <AssemblyName>Demo.CustomMessageBox</AssemblyName>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="MvvmLightLibsStd10" Version="5.4.1.1" />
+    <PackageReference Include="Ookii.Dialogs.Wpf" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/net-core/Demo.CustomMessageBox/app.manifest
+++ b/samples/net-core/Demo.CustomMessageBox/app.manifest
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+</assembly>


### PR DESCRIPTION
... now that Ookii.Dialogs targets .NET Core 3.1 and .NET 5.

### net-core/Demo.CustomMessageBox

- The `app.manifest` with the reference to `Microsoft.Windows.Common-Controls` is a new requirement for .NET Core apps using Ookii Dialogs ([more details here](https://github.com/augustoproiete-repros/repro-wpf-net5-comctl32-entrypointnotfoundexception))

- PR #136 already covers updating Ookii.Dialogs in the corresponding .NET Framework project