### PR TITLE
Update net-core/Demo.CustomOpenFileDialog to use Ookii.Dialogs...

### DIFF
--- a/samples/net-core/Demo.CustomOpenFileDialog/CustomOpenFileDialog.cs
+++ b/samples/net-core/Demo.CustomOpenFileDialog/CustomOpenFileDialog.cs
@@ -1,18 +1,15 @@
 ﻿using System;
 using System.Windows;
-using Microsoft.Win32;
 using MvvmDialogs.FrameworkDialogs;
 using MvvmDialogs.FrameworkDialogs.OpenFile;
+using Ookii.Dialogs.Wpf;
 
 namespace Demo.CustomOpenFileDialog
 {
-    /// <remarks>
-    /// This sample differs from the .NET Framework equivalent. The reason for that is that the
-    /// dependency Ookii.Dialogs.Wpf currently doesn't support .NET Core 3.
-    /// </remarks>
     public class CustomOpenFileDialog : IFrameworkDialog
     {
         private readonly OpenFileDialogSettings settings;
+        private readonly VistaOpenFileDialog openFileDialog;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomOpenFileDialog"/> class.
@@ -21,6 +18,20 @@ namespace Demo.CustomOpenFileDialog
         public CustomOpenFileDialog(OpenFileDialogSettings settings)
         {
             this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+            openFileDialog = new VistaOpenFileDialog
+            {
+                AddExtension = settings.AddExtension,
+                CheckFileExists = settings.CheckFileExists,
+                CheckPathExists = settings.CheckPathExists,
+                DefaultExt = settings.DefaultExt,
+                FileName = settings.FileName,
+                Filter = settings.Filter,
+                FilterIndex = settings.FilterIndex,
+                InitialDirectory = settings.InitialDirectory,
+                Multiselect = settings.Multiselect,
+                Title = settings.Title
+            };
         }
 
         /// <summary>
@@ -36,26 +47,12 @@ namespace Demo.CustomOpenFileDialog
         {
             if (owner == null) throw new ArgumentNullException(nameof(owner));
 
-            var dialog = new OpenFileDialog
-            {
-                AddExtension = settings.AddExtension,
-                CheckFileExists = settings.CheckFileExists,
-                CheckPathExists = settings.CheckPathExists,
-                DefaultExt = settings.DefaultExt,
-                FileName = settings.FileName,
-                Filter = settings.Filter,
-                FilterIndex = settings.FilterIndex,
-                InitialDirectory = settings.InitialDirectory,
-                Multiselect = settings.Multiselect,
-                Title = settings.Title
-            };
-
-            var result = dialog.ShowDialog(owner);
+            var result = openFileDialog.ShowDialog(owner);
 
             // Update settings
-            settings.FileName = dialog.FileName;
-            settings.FileNames = dialog.FileNames;
-            settings.FilterIndex = dialog.FilterIndex;
+            settings.FileName = openFileDialog.FileName;
+            settings.FileNames = openFileDialog.FileNames;
+            settings.FilterIndex = openFileDialog.FilterIndex;
 
             return result;
         }

--- a/samples/net-core/Demo.CustomOpenFileDialog/Demo.CustomOpenFileDialog.Core.csproj
+++ b/samples/net-core/Demo.CustomOpenFileDialog/Demo.CustomOpenFileDialog.Core.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CustomOpenFileDialog</RootNamespace>
     <AssemblyName>Demo.CustomOpenFileDialog</AssemblyName>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="MvvmLightLibsStd10" Version="5.4.1.1" />
+    <PackageReference Include="Ookii.Dialogs.Wpf" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/net-core/Demo.CustomOpenFileDialog/app.manifest
+++ b/samples/net-core/Demo.CustomOpenFileDialog/app.manifest
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+</assembly>


### PR DESCRIPTION
... now that Ookii.Dialogs targets .NET Core 3.1 and .NET 5.

### net-core/Demo.CustomOpenFileDialog

- The `app.manifest` with the reference to `Microsoft.Windows.Common-Controls` is a new requirement for .NET Core apps using Ookii Dialogs ([more details here](https://github.com/augustoproiete-repros/repro-wpf-net5-comctl32-entrypointnotfoundexception))

- PR #136 already covers updating Ookii.Dialogs in the corresponding .NET Framework project