### PR TITLE
Update net-core/Demo.CustomSaveFileDialog to use Ookii.Dialogs...

### DIFF
--- a/samples/net-core/Demo.CustomSaveFileDialog/CustomSaveFileDialog.cs
+++ b/samples/net-core/Demo.CustomSaveFileDialog/CustomSaveFileDialog.cs
@@ -1,18 +1,15 @@
 ﻿using System;
 using System.Windows;
-using Microsoft.Win32;
 using MvvmDialogs.FrameworkDialogs;
 using MvvmDialogs.FrameworkDialogs.SaveFile;
+using Ookii.Dialogs.Wpf;
 
 namespace Demo.CustomSaveFileDialog
 {
-    /// <remarks>
-    /// This sample differs from the .NET Framework equivalent. The reason for that is that the
-    /// dependency Ookii.Dialogs.Wpf currently doesn't support .NET Core 3.
-    /// </remarks>
     public class CustomSaveFileDialog : IFrameworkDialog
     {
         private readonly SaveFileDialogSettings settings;
+        private readonly VistaSaveFileDialog saveFileDialog;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomSaveFileDialog"/> class.
@@ -21,6 +18,21 @@ namespace Demo.CustomSaveFileDialog
         public CustomSaveFileDialog(SaveFileDialogSettings settings)
         {
             this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+            saveFileDialog = new VistaSaveFileDialog
+            {
+                AddExtension = settings.AddExtension,
+                CheckFileExists = settings.CheckFileExists,
+                CheckPathExists = settings.CheckPathExists,
+                CreatePrompt = settings.CreatePrompt,
+                DefaultExt = settings.DefaultExt,
+                FileName = settings.FileName,
+                Filter = settings.Filter,
+                FilterIndex = settings.FilterIndex,
+                InitialDirectory = settings.InitialDirectory,
+                OverwritePrompt = settings.OverwritePrompt,
+                Title = settings.Title
+            };
         }
 
         /// <summary>
@@ -36,27 +48,12 @@ namespace Demo.CustomSaveFileDialog
         {
             if (owner == null) throw new ArgumentNullException(nameof(owner));
 
-            var dialog = new SaveFileDialog
-            {
-                AddExtension = settings.AddExtension,
-                CheckFileExists = settings.CheckFileExists,
-                CheckPathExists = settings.CheckPathExists,
-                CreatePrompt = settings.CreatePrompt,
-                DefaultExt = settings.DefaultExt,
-                FileName = settings.FileName,
-                Filter = settings.Filter,
-                FilterIndex = settings.FilterIndex,
-                InitialDirectory = settings.InitialDirectory,
-                OverwritePrompt = settings.OverwritePrompt,
-                Title = settings.Title
-            };
-
-            var result = dialog.ShowDialog(owner);
+            var result = saveFileDialog.ShowDialog(owner);
 
             // Update settings
-            settings.FileName = dialog.FileName;
-            settings.FileNames = dialog.FileNames;
-            settings.FilterIndex = dialog.FilterIndex;
+            settings.FileName = saveFileDialog.FileName;
+            settings.FileNames = saveFileDialog.FileNames;
+            settings.FilterIndex = saveFileDialog.FilterIndex;
 
             return result;
         }

--- a/samples/net-core/Demo.CustomSaveFileDialog/Demo.CustomSaveFileDialog.Core.csproj
+++ b/samples/net-core/Demo.CustomSaveFileDialog/Demo.CustomSaveFileDialog.Core.csproj
@@ -6,10 +6,12 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CustomSaveFileDialog</RootNamespace>
     <AssemblyName>Demo.CustomSaveFileDialog</AssemblyName>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
+    <PackageReference Include="Ookii.Dialogs.Wpf" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/net-core/Demo.CustomSaveFileDialog/app.manifest
+++ b/samples/net-core/Demo.CustomSaveFileDialog/app.manifest
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+</assembly>


### PR DESCRIPTION
... now that Ookii.Dialogs targets .NET Core 3.1 and .NET 5.

### net-core/Demo.CustomSaveFileDialog

- The `app.manifest` with the reference to `Microsoft.Windows.Common-Controls` is a new requirement for .NET Core apps using Ookii Dialogs ([more details here](https://github.com/augustoproiete-repros/repro-wpf-net5-comctl32-entrypointnotfoundexception))

- PR #136 already covers updating Ookii.Dialogs in the corresponding .NET Framework project