### PR TITLE
Set csproj property "Nullable" to "enable" 

### DIFF
--- a/samples/wpf/Demo.ActivateNonModalDialog.Test/Demo.ActivateNonModalDialog.Test.csproj
+++ b/samples/wpf/Demo.ActivateNonModalDialog.Test/Demo.ActivateNonModalDialog.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.ActivateNonModalDialog</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.ActivateNonModalDialog\Demo.ActivateNonModalDialog.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.ActivateNonModalDialog.Test/MainWindowViewModelTest.cs
+++ b/samples/wpf/Demo.ActivateNonModalDialog.Test/MainWindowViewModelTest.cs
@@ -7,19 +7,13 @@ namespace Demo.ActivateNonModalDialog
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService;
-        private MainWindowViewModel viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowViewModel(dialogService.Object);
-        }
-
         [Test]
         public void CanShow()
         {
+            // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             // Act
             bool canShow = viewModel.ShowCommand.CanExecute(null);
 
@@ -31,6 +25,9 @@ namespace Demo.ActivateNonModalDialog
         public void CanNotShow()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             viewModel.ShowCommand.Execute(null);
 
             // Act
@@ -44,6 +41,9 @@ namespace Demo.ActivateNonModalDialog
         public void CanActivate()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             viewModel.ShowCommand.Execute(null);
 
             // Act
@@ -56,6 +56,10 @@ namespace Demo.ActivateNonModalDialog
         [Test]
         public void CanNotActivate()
         {
+            // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             // Act
             bool canActivate = viewModel.ActivateCommand.CanExecute(null);
 

--- a/samples/wpf/Demo.ActivateNonModalDialog/CurrentTimeDialogViewModel.cs
+++ b/samples/wpf/Demo.ActivateNonModalDialog/CurrentTimeDialogViewModel.cs
@@ -9,7 +9,7 @@ namespace Demo.ActivateNonModalDialog
     public class CurrentTimeDialogViewModel : ObservableObject
     {
         // ReSharper disable once NotAccessedField.Local
-        private DispatcherTimer timer;
+        private DispatcherTimer? timer;
 
         public CurrentTimeDialogViewModel()
         {
@@ -29,7 +29,7 @@ namespace Demo.ActivateNonModalDialog
                 Dispatcher.CurrentDispatcher);
         }
 
-        private void OnTick(object sender, EventArgs e)
+        private void OnTick(object? sender, EventArgs e)
         {
             OnPropertyChanged(nameof(CurrentTime));
         }

--- a/samples/wpf/Demo.ActivateNonModalDialog/Demo.ActivateNonModalDialog.csproj
+++ b/samples/wpf/Demo.ActivateNonModalDialog/Demo.ActivateNonModalDialog.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.ActivateNonModalDialog</RootNamespace>
     <AssemblyName>Demo.ActivateNonModalDialog</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.ActivateNonModalDialog/MainWindowViewModel.cs
+++ b/samples/wpf/Demo.ActivateNonModalDialog/MainWindowViewModel.cs
@@ -9,7 +9,7 @@ namespace Demo.ActivateNonModalDialog
     {
         private readonly IDialogService dialogService;
 
-        private INotifyPropertyChanged dialogViewModel;
+        private INotifyPropertyChanged? dialogViewModel;
 
         public MainWindowViewModel(IDialogService dialogService)
         {
@@ -39,7 +39,7 @@ namespace Demo.ActivateNonModalDialog
 
         private void Activate()
         {
-            dialogService.Activate(dialogViewModel);
+            dialogService.Activate(dialogViewModel!);
         }
 
         private bool CanActivate()

--- a/samples/wpf/Demo.CloseNonModalDialog.Test/Demo.CloseNonModalDialog.Test.csproj
+++ b/samples/wpf/Demo.CloseNonModalDialog.Test/Demo.CloseNonModalDialog.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.CloseNonModalDialog</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.CloseNonModalDialog\Demo.CloseNonModalDialog.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.CloseNonModalDialog.Test/MainWindowViewModelTest.cs
+++ b/samples/wpf/Demo.CloseNonModalDialog.Test/MainWindowViewModelTest.cs
@@ -7,19 +7,14 @@ namespace Demo.CloseNonModalDialog
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService;
-        private MainWindowViewModel viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowViewModel(dialogService.Object);
-        }
 
         [Test]
         public void CanShow()
         {
+            // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             // Act
             bool canShow = viewModel.ShowCommand.CanExecute(null);
 
@@ -31,6 +26,9 @@ namespace Demo.CloseNonModalDialog
         public void CanNotShow()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             viewModel.ShowCommand.Execute(null);
 
             // Act
@@ -44,6 +42,9 @@ namespace Demo.CloseNonModalDialog
         public void CanClose()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             viewModel.ShowCommand.Execute(null);
 
             // Act
@@ -56,6 +57,10 @@ namespace Demo.CloseNonModalDialog
         [Test]
         public void CanNotClose()
         {
+            // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             // Act
             bool canClose = viewModel.CloseCommand.CanExecute(null);
 

--- a/samples/wpf/Demo.CloseNonModalDialog/CurrentTimeDialogViewModel.cs
+++ b/samples/wpf/Demo.CloseNonModalDialog/CurrentTimeDialogViewModel.cs
@@ -9,7 +9,7 @@ namespace Demo.CloseNonModalDialog
     public class CurrentTimeDialogViewModel : ObservableObject
     {
         // ReSharper disable once NotAccessedField.Local
-        private DispatcherTimer timer;
+        private DispatcherTimer? timer;
 
         public CurrentTimeDialogViewModel()
         {
@@ -29,7 +29,7 @@ namespace Demo.CloseNonModalDialog
                 Dispatcher.CurrentDispatcher);
         }
 
-        private void OnTick(object sender, EventArgs e)
+        private void OnTick(object? sender, EventArgs e)
         {
             OnPropertyChanged(nameof(CurrentTime));
         }

--- a/samples/wpf/Demo.CloseNonModalDialog/Demo.CloseNonModalDialog.csproj
+++ b/samples/wpf/Demo.CloseNonModalDialog/Demo.CloseNonModalDialog.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CloseNonModalDialog</RootNamespace>
     <AssemblyName>Demo.CloseNonModalDialog</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.CloseNonModalDialog/MainWindowViewModel.cs
+++ b/samples/wpf/Demo.CloseNonModalDialog/MainWindowViewModel.cs
@@ -9,7 +9,7 @@ namespace Demo.CloseNonModalDialog
     {
         private readonly IDialogService dialogService;
 
-        private INotifyPropertyChanged dialogViewModel;
+        private INotifyPropertyChanged? dialogViewModel;
 
         public MainWindowViewModel(IDialogService dialogService)
         {
@@ -39,7 +39,7 @@ namespace Demo.CloseNonModalDialog
 
         private void Close()
         {
-            dialogService.Close(dialogViewModel);
+            dialogService.Close(dialogViewModel!);
             dialogViewModel = null;
 
             ShowCommand.NotifyCanExecuteChanged();

--- a/samples/wpf/Demo.CustomDialogTypeLocator.Test/Demo.CustomDialogTypeLocator.Test.csproj
+++ b/samples/wpf/Demo.CustomDialogTypeLocator.Test/Demo.CustomDialogTypeLocator.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.CustomDialogTypeLocator</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.CustomDialogTypeLocator\Demo.CustomDialogTypeLocator.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.CustomDialogTypeLocator.Test/MyCustomDialogTypeLocatorTest.cs
+++ b/samples/wpf/Demo.CustomDialogTypeLocator.Test/MyCustomDialogTypeLocatorTest.cs
@@ -7,19 +7,13 @@ namespace Demo.CustomDialogTypeLocator
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService;
-        private MainWindowVM viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowVM(dialogService.Object);
-        }
-
         [Test]
         public void ShowDialog()
         {
+            // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowVM(dialogService.Object);
+
             // Act
             viewModel.ShowDialogCommand.Execute(null);
 

--- a/samples/wpf/Demo.CustomDialogTypeLocator/Demo.CustomDialogTypeLocator.csproj
+++ b/samples/wpf/Demo.CustomDialogTypeLocator/Demo.CustomDialogTypeLocator.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CustomDialogTypeLocator</RootNamespace>
     <AssemblyName>Demo.CustomDialogTypeLocator</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.CustomDialogTypeLocator/MyCustomDialogTypeLocator.cs
+++ b/samples/wpf/Demo.CustomDialogTypeLocator/MyCustomDialogTypeLocator.cs
@@ -11,14 +11,25 @@ namespace Demo.CustomDialogTypeLocator
         public Type Locate(INotifyPropertyChanged viewModel)
         {
             Type viewModelType = viewModel.GetType();
-            string viewModelTypeName = viewModelType.FullName;
+            string? viewModelTypeName = viewModelType.FullName;
+
+            if (viewModelTypeName == null)
+            {
+                throw new Exception($"Type {viewModelType} has no full name");
+            }
 
             // Get dialog type name by removing the 'VM' suffix
             string dialogTypeName = viewModelTypeName.Substring(
                 0,
                 viewModelTypeName.Length - "VM".Length);
 
-            return viewModelType.Assembly.GetType(dialogTypeName);
+            var type = viewModelType.Assembly.GetType(dialogTypeName);
+            if (type == null)
+            {
+                throw new Exception($"Unable to find dialog type with name {dialogTypeName}");
+            }
+
+            return type;
         }
     }
 }

--- a/samples/wpf/Demo.CustomFolderBrowserDialog.Test/Demo.CustomFolderBrowserDialog.Test.csproj
+++ b/samples/wpf/Demo.CustomFolderBrowserDialog.Test/Demo.CustomFolderBrowserDialog.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.CustomFolderBrowserDialog</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.CustomFolderBrowserDialog\Demo.CustomFolderBrowserDialog.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.CustomFolderBrowserDialog.Test/Features/BrowseFolderSteps.cs
+++ b/samples/wpf/Demo.CustomFolderBrowserDialog.Test/Features/BrowseFolderSteps.cs
@@ -13,7 +13,7 @@ namespace Demo.CustomFolderBrowserDialog.Features
     [Binding]
     public class BrowseFolderSteps : FeatureSteps<MainScreen>
     {
-        private BrowseFolderScreen browseFolderScreen;
+        private BrowseFolderScreen? browseFolderScreen;
 
         protected override Application LaunchApplication()
         {
@@ -33,31 +33,31 @@ namespace Demo.CustomFolderBrowserDialog.Features
         [Given("I have browsed a folder")]
         public void GivenIHaveBrowsedAFolder()
         {
-            browseFolderScreen = MainScreen.ClickBrowse();
+            browseFolderScreen = MainScreen!.ClickBrowse();
         }
         
         [When("I press confirm")]
         public void WhenIPressConfirm()
         {
-            browseFolderScreen.ClickSelectFolder();
+            browseFolderScreen!.ClickSelectFolder();
         }
         
         [When("I cancel")]
         public void WhenICancel()
         {
-            browseFolderScreen.ClickCancel();
+            browseFolderScreen!.ClickCancel();
         }
         
         [Then("the folder should be opened")]
         public void ThenTheFolderShouldBeOpened()
         {
-            Assert.That(MainScreen.FileName, Is.Not.Empty);
+            Assert.That(MainScreen!.FileName, Is.Not.Empty);
         }
         
         [Then("the folder should not be opened")]
         public void ThenTheFolderShouldNotBeOpened()
         {
-            Assert.That(MainScreen.FileName, Is.Empty);
+            Assert.That(MainScreen!.FileName, Is.Empty);
         }
     }
 }

--- a/samples/wpf/Demo.CustomFolderBrowserDialog.Test/MainWindowViewModelTest.cs
+++ b/samples/wpf/Demo.CustomFolderBrowserDialog.Test/MainWindowViewModelTest.cs
@@ -9,20 +9,13 @@ namespace Demo.CustomFolderBrowserDialog
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService;
-        private MainWindowViewModel viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowViewModel(dialogService.Object);
-        }
-
         [Test]
         public void BrowseFolderSuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowFolderBrowserDialog(viewModel, It.IsAny<FolderBrowserDialogSettings>()))
                 .Returns(true)
@@ -40,6 +33,9 @@ namespace Demo.CustomFolderBrowserDialog
         public void BrowseFolderUnsuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowFolderBrowserDialog(viewModel, It.IsAny<FolderBrowserDialogSettings>()))
                 .Returns(false);

--- a/samples/wpf/Demo.CustomFolderBrowserDialog.Test/ScreenObjects/MainScreen.cs
+++ b/samples/wpf/Demo.CustomFolderBrowserDialog.Test/ScreenObjects/MainScreen.cs
@@ -9,21 +9,21 @@ namespace Demo.CustomFolderBrowserDialog.ScreenObjects
     public class MainScreen : AppScreen
     {
         [AutomationId("RQ_N2kIsN0C39sxTonCRtA")]
-        private readonly TextBox pathTextBox = null;
+        private readonly TextBox? pathTextBox = null;
 
         [AutomationId("TTK4W3coCE2skIHpcUe97Q")]
-        private readonly Button browseButton = null;
+        private readonly Button? browseButton = null;
 
         public MainScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
         {
         }
 
-        public virtual string FileName => pathTextBox.Text;
+        public virtual string? FileName => pathTextBox?.Text;
 
         public virtual BrowseFolderScreen ClickBrowse()
         {
-            browseButton.Click();
+            browseButton!.Click();
             return ScreenRepository.GetModal<BrowseFolderScreen>("Select Folder", Window, InitializeOption.NoCache);
         }
     }

--- a/samples/wpf/Demo.CustomFolderBrowserDialog/Demo.CustomFolderBrowserDialog.csproj
+++ b/samples/wpf/Demo.CustomFolderBrowserDialog/Demo.CustomFolderBrowserDialog.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CustomFolderBrowserDialog</RootNamespace>
     <AssemblyName>Demo.CustomFolderBrowserDialog</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.CustomFolderBrowserDialog/MainWindowViewModel.cs
+++ b/samples/wpf/Demo.CustomFolderBrowserDialog/MainWindowViewModel.cs
@@ -12,7 +12,7 @@ namespace Demo.CustomFolderBrowserDialog
     {
         private readonly IDialogService dialogService;
 
-        private string path;
+        private string? path;
 
         public MainWindowViewModel(IDialogService dialogService)
         {
@@ -21,7 +21,7 @@ namespace Demo.CustomFolderBrowserDialog
             BrowseFolderCommand = new RelayCommand(BrowseFolder);
         }
 
-        public string Path
+        public string? Path
         {
             get => path;
             private set => SetProperty(ref path, value);
@@ -34,7 +34,7 @@ namespace Demo.CustomFolderBrowserDialog
             var settings = new FolderBrowserDialogSettings
             {
                 Description = "This is a description",
-                SelectedPath = IOPath.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
+                SelectedPath = IOPath.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!
             };
 
             bool? success = dialogService.ShowFolderBrowserDialog(this, settings);

--- a/samples/wpf/Demo.CustomMessageBox.Test/Demo.CustomMessageBox.Test.csproj
+++ b/samples/wpf/Demo.CustomMessageBox.Test/Demo.CustomMessageBox.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.CustomMessageBox</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.CustomMessageBox\Demo.CustomMessageBox.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.CustomMessageBox.Test/Features/ConfirmationSteps.cs
+++ b/samples/wpf/Demo.CustomMessageBox.Test/Features/ConfirmationSteps.cs
@@ -13,7 +13,7 @@ namespace Demo.CustomMessageBox.Features
     [Binding]
     public class ConfirmationSteps : FeatureSteps<MainScreen>
     {
-        private MessageBoxScreen messageBoxScreen;
+        private MessageBoxScreen? messageBoxScreen;
 
         protected override Application LaunchApplication()
         {
@@ -27,13 +27,13 @@ namespace Demo.CustomMessageBox.Features
 
         protected override MainScreen GetMainScreen(ScreenRepository screenRepository)
         {
-            return ScreenRepository.Get<MainScreen>("Demo - Custom Message Box", InitializeOption.NoCache);
+            return ScreenRepository!.Get<MainScreen>("Demo - Custom Message Box", InitializeOption.NoCache);
         }
 
         [Given("confirmation with text is shown")]
         public void ShowConfirmationWithText()
         {
-            messageBoxScreen = MainScreen.ClickMessageBoxWithMessage();
+            messageBoxScreen = MainScreen!.ClickMessageBoxWithMessage();
 
             Assert.That(messageBoxScreen.Caption, Is.EqualTo(" "));
             Assert.That(messageBoxScreen.IsOKButtonVisible, Is.True);
@@ -43,7 +43,7 @@ namespace Demo.CustomMessageBox.Features
         [Given("confirmation with text and caption is shown")]
         public void ShowConfirmationWithTextAndCaption()
         {
-            messageBoxScreen = MainScreen.ClickMessageBoxWithCaption();
+            messageBoxScreen = MainScreen!.ClickMessageBoxWithCaption();
 
             Assert.That(messageBoxScreen.Caption, Is.EqualTo("This Is The Caption"));
             Assert.That(messageBoxScreen.IsOKButtonVisible, Is.True);
@@ -53,7 +53,7 @@ namespace Demo.CustomMessageBox.Features
         [Given("confirmation with text, caption and option to cancel is shown")]
         public void ShowConfirmationWithTextCaptionAndOptionToCancel()
         {
-            messageBoxScreen = MainScreen.ClickMessageBoxWithButtons();
+            messageBoxScreen = MainScreen!.ClickMessageBoxWithButtons();
 
             Assert.That(messageBoxScreen.Caption, Is.EqualTo("This Is The Caption"));
             Assert.That(messageBoxScreen.IsOKButtonVisible, Is.True);
@@ -63,7 +63,7 @@ namespace Demo.CustomMessageBox.Features
         [Given("confirmation with text, caption, icon and option to cancel is shown")]
         public void ShowConfirmationWithTextCaptionAndIcon()
         {
-            messageBoxScreen = MainScreen.ClickMessageBoxWithIcon();
+            messageBoxScreen = MainScreen!.ClickMessageBoxWithIcon();
 
             Assert.That(messageBoxScreen.Caption, Is.EqualTo("This Is The Caption"));
             Assert.That(messageBoxScreen.IsOKButtonVisible, Is.True);
@@ -73,7 +73,7 @@ namespace Demo.CustomMessageBox.Features
         [Given("confirmation with text, caption, icon, default choice and option to cancel is shown")]
         public void ShowConfirmationWithTextCaptionIconAndDefaultChoice()
         {
-            messageBoxScreen = MainScreen.ClickMessageBoxWithDefaultResult();
+            messageBoxScreen = MainScreen!.ClickMessageBoxWithDefaultResult();
 
             Assert.That(messageBoxScreen.Caption, Is.EqualTo("This Is The Caption"));
             Assert.That(messageBoxScreen.IsOKButtonVisible, Is.True);
@@ -83,25 +83,25 @@ namespace Demo.CustomMessageBox.Features
         [When("I confirm")]
         public void WhenIConfirm()
         {
-            messageBoxScreen.ClickOK();
+            messageBoxScreen!.ClickOK();
         }
 
         [When("I cancel")]
         public void WhenICancel()
         {
-            messageBoxScreen.ClickCancel();
+            messageBoxScreen!.ClickCancel();
         }
 
         [Then("the confirmation should be acted on")]
         public void VerifyThatConfirmationWasActedOn()
         {
-            Assert.That(MainScreen.Confirmation, Is.EqualTo("We got confirmation to continue!"));
+            Assert.That(MainScreen!.Confirmation, Is.EqualTo("We got confirmation to continue!"));
         }
 
         [Then("the cancellation should be respected")]
         public void VerifyThatCancellationWasRespected()
         {
-            Assert.That(MainScreen.Confirmation, Is.Empty);
+            Assert.That(MainScreen!.Confirmation, Is.Empty);
         }
     }
 }

--- a/samples/wpf/Demo.CustomMessageBox.Test/MainWindowViewModelTest.cs
+++ b/samples/wpf/Demo.CustomMessageBox.Test/MainWindowViewModelTest.cs
@@ -8,20 +8,13 @@ namespace Demo.CustomMessageBox
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService;
-        private MainWindowViewModel viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowViewModel(dialogService.Object);
-        }
-
         [Test]
         public void ShowMessageBoxWithMessage()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock =>
                     mock.ShowMessageBox(
@@ -44,6 +37,9 @@ namespace Demo.CustomMessageBox
         public void ShowMessageBoxWithCaption()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock =>
                     mock.ShowMessageBox(
@@ -66,6 +62,9 @@ namespace Demo.CustomMessageBox
         public void ShowMessageBoxWithButton()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock =>
                     mock.ShowMessageBox(
@@ -88,6 +87,9 @@ namespace Demo.CustomMessageBox
         public void ShowMessageBoxWithIcon()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock =>
                     mock.ShowMessageBox(
@@ -110,6 +112,9 @@ namespace Demo.CustomMessageBox
         public void ShowMessageBoxWithDefaultResult()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock =>
                     mock.ShowMessageBox(

--- a/samples/wpf/Demo.CustomMessageBox.Test/ScreenObjects/MainScreen.cs
+++ b/samples/wpf/Demo.CustomMessageBox.Test/ScreenObjects/MainScreen.cs
@@ -9,57 +9,57 @@ namespace Demo.CustomMessageBox.ScreenObjects
     public class MainScreen : AppScreen
     {
         [AutomationId("1k7d1Nm8MkOYK5qGrdVX4Q")]
-        private readonly Button messageBoxWithMessageButton = null;
+        private readonly Button? messageBoxWithMessageButton = null;
 
         [AutomationId("EvNqZT9tYkuNzKDDrLJ8Yw")]
-        private readonly Button messageBoxWithCaptionButton = null;
+        private readonly Button? messageBoxWithCaptionButton = null;
 
         [AutomationId("FWGzBkom5ESJz_p7KCPKqQ")]
-        private readonly Button messageBoxWithButtonsButton = null;
+        private readonly Button? messageBoxWithButtonsButton = null;
 
         [AutomationId("SapYi2J7bkiJ1z1GWwOZAQ")]
-        private readonly Button messageBoxWithIconButton = null;
+        private readonly Button? messageBoxWithIconButton = null;
 
         [AutomationId("sUjm2_m1LUGWso8S2Us5ow")]
-        private readonly Button messageBoxWithDefaultResultButton = null;
+        private readonly Button? messageBoxWithDefaultResultButton = null;
 
         [AutomationId("kT3_ZUZfsEK1QdZ2jBfuIQ")]
-        private readonly Label confirmation = null;
+        private readonly Label? confirmation = null;
 
         public MainScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
         {
         }
 
-        public virtual string Confirmation => confirmation.Text;
+        public virtual string? Confirmation => confirmation?.Text;
 
         public virtual MessageBoxScreen ClickMessageBoxWithMessage()
         {
-            messageBoxWithMessageButton.Click();
+            messageBoxWithMessageButton!.Click();
             return ScreenRepository.GetModal<MessageBoxScreen>(" ", Window, InitializeOption.NoCache);
         }
 
         public virtual MessageBoxScreen ClickMessageBoxWithCaption()
         {
-            messageBoxWithCaptionButton.Click();
+            messageBoxWithCaptionButton!.Click();
             return ScreenRepository.GetModal<MessageBoxScreen>("This Is The Caption", Window, InitializeOption.NoCache);
         }
 
         public virtual MessageBoxScreen ClickMessageBoxWithButtons()
         {
-            messageBoxWithButtonsButton.Click();
+            messageBoxWithButtonsButton!.Click();
             return ScreenRepository.GetModal<MessageBoxScreen>("This Is The Caption", Window, InitializeOption.NoCache);
         }
 
         public virtual MessageBoxScreen ClickMessageBoxWithIcon()
         {
-            messageBoxWithIconButton.Click();
+            messageBoxWithIconButton!.Click();
             return ScreenRepository.GetModal<MessageBoxScreen>("This Is The Caption", Window, InitializeOption.NoCache);
         }
 
         public virtual MessageBoxScreen ClickMessageBoxWithDefaultResult()
         {
-            messageBoxWithDefaultResultButton.Click();
+            messageBoxWithDefaultResultButton!.Click();
             return ScreenRepository.GetModal<MessageBoxScreen>("This Is The Caption", Window, InitializeOption.NoCache);
         }
     }

--- a/samples/wpf/Demo.CustomMessageBox/Demo.CustomMessageBox.csproj
+++ b/samples/wpf/Demo.CustomMessageBox/Demo.CustomMessageBox.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CustomMessageBox</RootNamespace>
     <AssemblyName>Demo.CustomMessageBox</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.CustomMessageBox/MainWindowViewModel.cs
+++ b/samples/wpf/Demo.CustomMessageBox/MainWindowViewModel.cs
@@ -11,7 +11,7 @@ namespace Demo.CustomMessageBox
     {
         private readonly IDialogService dialogService;
 
-        private string confirmation;
+        private string? confirmation;
         
         public MainWindowViewModel(IDialogService dialogService)
         {
@@ -34,7 +34,7 @@ namespace Demo.CustomMessageBox
 
         public ICommand ShowMessageBoxWithDefaultResultCommand { get; }
 
-        public string Confirmation
+        public string? Confirmation
         {
             get => confirmation;
             private set => SetProperty(ref confirmation, value);

--- a/samples/wpf/Demo.CustomOpenFileDialog.Test/Demo.CustomOpenFileDialog.Test.csproj
+++ b/samples/wpf/Demo.CustomOpenFileDialog.Test/Demo.CustomOpenFileDialog.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.CustomOpenFileDialog</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.CustomOpenFileDialog\Demo.CustomOpenFileDialog.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.CustomOpenFileDialog.Test/Features/OpenFileSteps.cs
+++ b/samples/wpf/Demo.CustomOpenFileDialog.Test/Features/OpenFileSteps.cs
@@ -13,7 +13,7 @@ namespace Demo.CustomOpenFileDialog.Features
     [Binding]
     public class OpenFileSteps : FeatureSteps<MainScreen>
     {
-        private OpenFileScreen openFileScreen;
+        private OpenFileScreen? openFileScreen;
 
         protected override Application LaunchApplication()
         {
@@ -27,38 +27,38 @@ namespace Demo.CustomOpenFileDialog.Features
 
         protected override MainScreen GetMainScreen(ScreenRepository screenRepository)
         {
-            return ScreenRepository.Get<MainScreen>("Demo - Custom Open File Dialog", InitializeOption.NoCache);
+            return ScreenRepository!.Get<MainScreen>("Demo - Custom Open File Dialog", InitializeOption.NoCache);
         }
 
         [Given("I have selected to open a file")]
         public void OpenFile()
         {
-            openFileScreen = MainScreen.ClickOpen();
+            openFileScreen = MainScreen!.ClickOpen();
             openFileScreen.FileName = "OpenMe.txt";
         }
 
         [When("I press confirm")]
         public void Confirm()
         {
-            openFileScreen.ClickOpen();
+            openFileScreen!.ClickOpen();
         }
 
         [When("I cancel")]
         public void Cancel()
         {
-            openFileScreen.ClickCancel();
+            openFileScreen!.ClickCancel();
         }
 
         [Then("the file should be opened")]
         public void VerifyFileWasOpened()
         {
-            StringAssert.EndsWith("OpenMe.txt", MainScreen.FileName);
+            StringAssert.EndsWith("OpenMe.txt", MainScreen!.FileName);
         }
 
         [Then("the file should not be opened")]
         public void VerifyFileWasNotOpened()
         {
-            Assert.That(MainScreen.FileName, Is.Empty);
+            Assert.That(MainScreen!.FileName, Is.Empty);
         }
     }
 }

--- a/samples/wpf/Demo.CustomOpenFileDialog.Test/MainWindowViewModelTest.cs
+++ b/samples/wpf/Demo.CustomOpenFileDialog.Test/MainWindowViewModelTest.cs
@@ -9,20 +9,13 @@ namespace Demo.CustomOpenFileDialog
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService;
-        private MainWindowViewModel viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowViewModel(dialogService.Object);
-        }
-
         [Test]
         public void OpenFileSuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowOpenFileDialog(viewModel, It.IsAny<OpenFileDialogSettings>()))
                 .Returns(true)
@@ -40,6 +33,9 @@ namespace Demo.CustomOpenFileDialog
         public void OpenFileUnsuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowOpenFileDialog(viewModel, It.IsAny<OpenFileDialogSettings>()))
                 .Returns(false);

--- a/samples/wpf/Demo.CustomOpenFileDialog.Test/ScreenObjects/MainScreen.cs
+++ b/samples/wpf/Demo.CustomOpenFileDialog.Test/ScreenObjects/MainScreen.cs
@@ -9,21 +9,21 @@ namespace Demo.CustomOpenFileDialog.ScreenObjects
     public class MainScreen : AppScreen
     {
         [AutomationId("cqkeItgI3UaZc-mQ6mYPAA")]
-        private readonly TextBox pathTextBox = null;
+        private readonly TextBox? pathTextBox = null;
 
         [AutomationId("MZ16xHTzYE2UP8S9vd-EGw")]
-        private readonly Button openButton = null;
+        private readonly Button? openButton = null;
 
         public MainScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
         {
         }
 
-        public virtual string FileName => pathTextBox.Text;
+        public virtual string? FileName => pathTextBox?.Text;
 
         public virtual OpenFileScreen ClickOpen()
         {
-            openButton.Click();
+            openButton!.Click();
             return ScreenRepository.GetModal<OpenFileScreen>("This Is The Title", Window, InitializeOption.NoCache);
         }
     }

--- a/samples/wpf/Demo.CustomOpenFileDialog/Demo.CustomOpenFileDialog.csproj
+++ b/samples/wpf/Demo.CustomOpenFileDialog/Demo.CustomOpenFileDialog.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CustomOpenFileDialog</RootNamespace>
     <AssemblyName>Demo.CustomOpenFileDialog</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.CustomOpenFileDialog/MainWindowViewModel.cs
+++ b/samples/wpf/Demo.CustomOpenFileDialog/MainWindowViewModel.cs
@@ -12,7 +12,7 @@ namespace Demo.CustomOpenFileDialog
     {
         private readonly IDialogService dialogService;
 
-        private string path;
+        private string? path;
 
         public MainWindowViewModel(IDialogService dialogService)
         {
@@ -21,7 +21,7 @@ namespace Demo.CustomOpenFileDialog
             OpenFileCommand = new RelayCommand(OpenFile);
         }
 
-        public string Path
+        public string? Path
         {
             get => path;
             private set => SetProperty(ref path, value);
@@ -34,7 +34,7 @@ namespace Demo.CustomOpenFileDialog
             var settings = new OpenFileDialogSettings
             {
                 Title = "This Is The Title",
-                InitialDirectory = IOPath.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                InitialDirectory = IOPath.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
                 Filter = "Text Documents (*.txt)|*.txt|All Files (*.*)|*.*"
             };
 

--- a/samples/wpf/Demo.CustomSaveFileDialog.Test/Demo.CustomSaveFileDialog.Test.csproj
+++ b/samples/wpf/Demo.CustomSaveFileDialog.Test/Demo.CustomSaveFileDialog.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.CustomSaveFileDialog</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.CustomSaveFileDialog\Demo.CustomSaveFileDialog.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.CustomSaveFileDialog.Test/Features/SaveFileSteps.cs
+++ b/samples/wpf/Demo.CustomSaveFileDialog.Test/Features/SaveFileSteps.cs
@@ -13,7 +13,7 @@ namespace Demo.CustomSaveFileDialog.Features
     [Binding]
     public class SaveFileSteps : FeatureSteps<MainScreen>
     {
-        private SaveFileScreen saveFileScreen;
+        private SaveFileScreen? saveFileScreen;
 
         protected override Application LaunchApplication()
         {
@@ -27,38 +27,38 @@ namespace Demo.CustomSaveFileDialog.Features
 
         protected override MainScreen GetMainScreen(ScreenRepository screenRepository)
         {
-            return ScreenRepository.Get<MainScreen>("Demo - Custom Save File Dialog", InitializeOption.NoCache);
+            return ScreenRepository!.Get<MainScreen>("Demo - Custom Save File Dialog", InitializeOption.NoCache);
         }
 
         [Given("I have selected to save a file")]
         public void SaveFile()
         {
-            saveFileScreen = MainScreen.ClickSave();
+            saveFileScreen = MainScreen!.ClickSave();
             saveFileScreen.FileName = "SaveMe.txt";
         }
 
         [When("I press confirm")]
         public void Confirm()
         {
-            saveFileScreen.ClickSave();
+            saveFileScreen!.ClickSave();
         }
 
         [When("I cancel")]
         public void Cancel()
         {
-            saveFileScreen.ClickCancel();
+            saveFileScreen!.ClickCancel();
         }
 
         [Then("the file should be saved")]
         public void VerifyFileWasSaved()
         {
-            StringAssert.EndsWith("SaveMe.txt", MainScreen.FileName);
+            StringAssert.EndsWith("SaveMe.txt", MainScreen!.FileName);
         }
 
         [Then("the file should not be saved")]
         public void VerifyFileWasNotSaved()
         {
-            Assert.That(MainScreen.FileName, Is.Empty);
+            Assert.That(MainScreen!.FileName, Is.Empty);
         }
     }
 }

--- a/samples/wpf/Demo.CustomSaveFileDialog.Test/MainWindowViewModelTest.cs
+++ b/samples/wpf/Demo.CustomSaveFileDialog.Test/MainWindowViewModelTest.cs
@@ -9,20 +9,13 @@ namespace Demo.CustomSaveFileDialog
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService;
-        private MainWindowViewModel viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowViewModel(dialogService.Object);
-        }
-
         [Test]
         public void SaveFileSuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowSaveFileDialog(viewModel, It.IsAny<SaveFileDialogSettings>()))
                 .Returns(true)
@@ -40,6 +33,9 @@ namespace Demo.CustomSaveFileDialog
         public void OpenFileUnsuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowSaveFileDialog(viewModel, It.IsAny<SaveFileDialogSettings>()))
                 .Returns(false);

--- a/samples/wpf/Demo.CustomSaveFileDialog.Test/ScreenObjects/MainScreen.cs
+++ b/samples/wpf/Demo.CustomSaveFileDialog.Test/ScreenObjects/MainScreen.cs
@@ -9,21 +9,21 @@ namespace Demo.CustomSaveFileDialog.ScreenObjects
     public class MainScreen : AppScreen
     {
         [AutomationId("-u3vcUdRMUaG4Af_kzSeZQ")]
-        private readonly TextBox pathTextBox = null;
+        private readonly TextBox? pathTextBox = null;
 
         [AutomationId("HstqC8HI9EOGiTfPA4_xag")]
-        private readonly Button saveButton = null;
+        private readonly Button? saveButton = null;
 
         public MainScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
         {
         }
 
-        public virtual string FileName => pathTextBox.Text;
+        public virtual string? FileName => pathTextBox?.Text;
 
         public virtual SaveFileScreen ClickSave()
         {
-            saveButton.Click();
+            saveButton!.Click();
             return ScreenRepository.GetModal<SaveFileScreen>("This Is The Title", Window, InitializeOption.NoCache);
         }
     }

--- a/samples/wpf/Demo.CustomSaveFileDialog/Demo.CustomSaveFileDialog.csproj
+++ b/samples/wpf/Demo.CustomSaveFileDialog/Demo.CustomSaveFileDialog.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CustomSaveFileDialog</RootNamespace>
     <AssemblyName>Demo.CustomSaveFileDialog</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.CustomSaveFileDialog/MainWindowViewModel.cs
+++ b/samples/wpf/Demo.CustomSaveFileDialog/MainWindowViewModel.cs
@@ -12,7 +12,7 @@ namespace Demo.CustomSaveFileDialog
     {
         private readonly IDialogService dialogService;
 
-        private string path;
+        private string? path;
 
         public MainWindowViewModel(IDialogService dialogService)
         {
@@ -21,7 +21,7 @@ namespace Demo.CustomSaveFileDialog
             SaveFileCommand = new RelayCommand(SaveFile);
         }
 
-        public string Path
+        public string? Path
         {
             get => path;
             private set => SetProperty(ref path, value);
@@ -34,7 +34,7 @@ namespace Demo.CustomSaveFileDialog
             var settings = new SaveFileDialogSettings
             {
                 Title = "This Is The Title",
-                InitialDirectory = IOPath.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                InitialDirectory = IOPath.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
                 Filter = "Text Documents (*.txt)|*.txt|All Files (*.*)|*.*",
                 CheckFileExists = false
             };

--- a/samples/wpf/Demo.FolderBrowserDialog.Test/Demo.FolderBrowserDialog.Test.csproj
+++ b/samples/wpf/Demo.FolderBrowserDialog.Test/Demo.FolderBrowserDialog.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.FolderBrowserDialog</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.FolderBrowserDialog\Demo.FolderBrowserDialog.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.FolderBrowserDialog.Test/Features/BrowseFolderSteps.cs
+++ b/samples/wpf/Demo.FolderBrowserDialog.Test/Features/BrowseFolderSteps.cs
@@ -13,7 +13,7 @@ namespace Demo.FolderBrowserDialog.Features
     [Binding]
     public class BrowseFolderSteps : FeatureSteps<MainScreen>
     {
-        private BrowseFolderScreen browseFolderScreen;
+        private BrowseFolderScreen? browseFolderScreen;
 
         protected override Application LaunchApplication()
         {
@@ -33,31 +33,31 @@ namespace Demo.FolderBrowserDialog.Features
         [Given("I have browsed a folder")]
         public void BrowseFolder()
         {
-            browseFolderScreen = MainScreen.ClickBrowse();
+            browseFolderScreen = MainScreen!.ClickBrowse();
         }
 
         [When("I press confirm")]
         public void Confirm()
         {
-            browseFolderScreen.ClickOK();
+            browseFolderScreen!.ClickOK();
         }
 
         [When("I cancel")]
         public void Cancel()
         {
-            browseFolderScreen.ClickCancel();
+            browseFolderScreen!.ClickCancel();
         }
 
         [Then("the folder should be opened")]
         public void VerifyFolderWasOpened()
         {
-            Assert.That(MainScreen.FileName, Is.Not.Empty);
+            Assert.That(MainScreen!.FileName, Is.Not.Empty);
         }
 
         [Then("the folder should not be opened")]
         public void VerifyFolderWasNotOpened()
         {
-            Assert.That(MainScreen.FileName, Is.Empty);
+            Assert.That(MainScreen!.FileName, Is.Empty);
         }
     }
 }

--- a/samples/wpf/Demo.FolderBrowserDialog.Test/MainWindowViewModelTest.cs
+++ b/samples/wpf/Demo.FolderBrowserDialog.Test/MainWindowViewModelTest.cs
@@ -9,20 +9,13 @@ namespace Demo.FolderBrowserDialog
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService;
-        private MainWindowViewModel viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowViewModel(dialogService.Object);
-        }
-
         [Test]
         public void BrowseFolderSuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowFolderBrowserDialog(viewModel, It.IsAny<FolderBrowserDialogSettings>()))
                 .Returns(true)
@@ -40,6 +33,9 @@ namespace Demo.FolderBrowserDialog
         public void BrowseFolderUnsuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowFolderBrowserDialog(viewModel, It.IsAny<FolderBrowserDialogSettings>()))
                 .Returns(false);

--- a/samples/wpf/Demo.FolderBrowserDialog.Test/ScreenObjects/MainScreen.cs
+++ b/samples/wpf/Demo.FolderBrowserDialog.Test/ScreenObjects/MainScreen.cs
@@ -9,21 +9,21 @@ namespace Demo.FolderBrowserDialog.ScreenObjects
     public class MainScreen : AppScreen
     {
         [AutomationId("RQ_N2kIsN0C39sxTonCRtA")]
-        private readonly TextBox pathTextBox = null;
+        private readonly TextBox? pathTextBox = null;
 
         [AutomationId("TTK4W3coCE2skIHpcUe97Q")]
-        private readonly Button browseButton = null;
+        private readonly Button? browseButton = null;
 
         public MainScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
         {
         }
 
-        public virtual string FileName => pathTextBox.Text;
+        public virtual string? FileName => pathTextBox?.Text;
 
         public virtual BrowseFolderScreen ClickBrowse()
         {
-            browseButton.Click();
+            browseButton!.Click();
             return ScreenRepository.GetModal<BrowseFolderScreen>("Browse For Folder", Window, InitializeOption.NoCache);
         }
     }

--- a/samples/wpf/Demo.FolderBrowserDialog/Demo.FolderBrowserDialog.csproj
+++ b/samples/wpf/Demo.FolderBrowserDialog/Demo.FolderBrowserDialog.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.FolderBrowserDialog</RootNamespace>
     <AssemblyName>Demo.FolderBrowserDialog</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.FolderBrowserDialog/MainWindowViewModel.cs
+++ b/samples/wpf/Demo.FolderBrowserDialog/MainWindowViewModel.cs
@@ -12,7 +12,7 @@ namespace Demo.FolderBrowserDialog
     {
         private readonly IDialogService dialogService;
 
-        private string path;
+        private string? path;
 
         public MainWindowViewModel(IDialogService dialogService)
         {
@@ -21,7 +21,7 @@ namespace Demo.FolderBrowserDialog
             BrowseFolderCommand = new RelayCommand(BrowseFolder);
         }
 
-        public string Path
+        public string? Path
         {
             get => path;
             private set => SetProperty(ref path, value);
@@ -34,7 +34,7 @@ namespace Demo.FolderBrowserDialog
             var settings = new FolderBrowserDialogSettings
             {
                 Description = "This is a description",
-                SelectedPath = IOPath.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
+                SelectedPath = IOPath.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!
             };
 
             bool? success = dialogService.ShowFolderBrowserDialog(this, settings);

--- a/samples/wpf/Demo.MessageBox.Test/Demo.MessageBox.Test.csproj
+++ b/samples/wpf/Demo.MessageBox.Test/Demo.MessageBox.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.MessageBox</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.MessageBox\Demo.MessageBox.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.MessageBox.Test/Features/ConfirmationSteps.cs
+++ b/samples/wpf/Demo.MessageBox.Test/Features/ConfirmationSteps.cs
@@ -13,7 +13,7 @@ namespace Demo.MessageBox.Features
     [Binding]
     public class ConfirmationSteps : FeatureSteps<MainScreen>
     {
-        private MessageBoxScreen messageBoxScreen;
+        private MessageBoxScreen? messageBoxScreen;
 
         protected override Application LaunchApplication()
         {
@@ -27,13 +27,13 @@ namespace Demo.MessageBox.Features
 
         protected override MainScreen GetMainScreen(ScreenRepository screenRepository)
         {
-            return ScreenRepository.Get<MainScreen>("Demo - Message Box", InitializeOption.NoCache);
+            return ScreenRepository!.Get<MainScreen>("Demo - Message Box", InitializeOption.NoCache);
         }
 
         [Given("confirmation with text is shown")]
         public void ShowConfirmationWithText()
         {
-            messageBoxScreen = MainScreen.ClickMessageBoxWithMessage();
+            messageBoxScreen = MainScreen!.ClickMessageBoxWithMessage();
 
             Assert.That(messageBoxScreen.Caption, Is.Empty);
             Assert.That(messageBoxScreen.Message, Is.EqualTo("This is the text."));
@@ -45,7 +45,7 @@ namespace Demo.MessageBox.Features
         [Given("confirmation with text and caption is shown")]
         public void ShowConfirmationWithTextAndCaption()
         {
-            messageBoxScreen = MainScreen.ClickMessageBoxWithCaption();
+            messageBoxScreen = MainScreen!.ClickMessageBoxWithCaption();
 
             Assert.That(messageBoxScreen.Caption, Is.EqualTo("This Is The Caption"));
             Assert.That(messageBoxScreen.Message, Is.EqualTo("This is the text."));
@@ -57,7 +57,7 @@ namespace Demo.MessageBox.Features
         [Given("confirmation with text, caption and option to cancel is shown")]
         public void ShowConfirmationWithTextCaptionAndOptionToCancel()
         {
-            messageBoxScreen = MainScreen.ClickMessageBoxWithButtons();
+            messageBoxScreen = MainScreen!.ClickMessageBoxWithButtons();
 
             Assert.That(messageBoxScreen.Caption, Is.EqualTo("This Is The Caption"));
             Assert.That(messageBoxScreen.Message, Is.EqualTo("This is the text."));
@@ -70,7 +70,7 @@ namespace Demo.MessageBox.Features
         [Given("confirmation with text, caption, icon and option to cancel is shown")]
         public void ShowConfirmationWithTextCaptionAndIcon()
         {
-            messageBoxScreen = MainScreen.ClickMessageBoxWithIcon();
+            messageBoxScreen = MainScreen!.ClickMessageBoxWithIcon();
 
             Assert.That(messageBoxScreen.Caption, Is.EqualTo("This Is The Caption"));
             Assert.That(messageBoxScreen.Message, Is.EqualTo("This is the text."));
@@ -82,7 +82,7 @@ namespace Demo.MessageBox.Features
         [Given("confirmation with text, caption, icon, default choice and option to cancel is shown")]
         public void ShowConfirmationWithTextCaptionIconAndDefaultChoice()
         {
-            messageBoxScreen = MainScreen.ClickMessageBoxWithDefaultResult();
+            messageBoxScreen = MainScreen!.ClickMessageBoxWithDefaultResult();
 
             Assert.That(messageBoxScreen.Caption, Is.EqualTo("This Is The Caption"));
             Assert.That(messageBoxScreen.Message, Is.EqualTo("This is the text."));
@@ -94,25 +94,25 @@ namespace Demo.MessageBox.Features
         [When("I confirm")]
         public void WhenIConfirm()
         {
-            messageBoxScreen.ClickOK();
+            messageBoxScreen!.ClickOK();
         }
 
         [When("I cancel")]
         public void WhenICancel()
         {
-            messageBoxScreen.ClickCancel();
+            messageBoxScreen!.ClickCancel();
         }
 
         [Then("the confirmation should be acted on")]
         public void VerifyThatConfirmationWasActedOn()
         {
-            Assert.That(MainScreen.Confirmation, Is.EqualTo("We got confirmation to continue!"));
+            Assert.That(MainScreen!.Confirmation, Is.EqualTo("We got confirmation to continue!"));
         }
 
         [Then("the cancellation should be respected")]
         public void VerifyThatCancellationWasRespected()
         {
-            Assert.That(MainScreen.Confirmation, Is.Empty);
+            Assert.That(MainScreen!.Confirmation, Is.Empty);
         }
     }
 }

--- a/samples/wpf/Demo.MessageBox.Test/MainWindowViewModelTest.cs
+++ b/samples/wpf/Demo.MessageBox.Test/MainWindowViewModelTest.cs
@@ -8,20 +8,13 @@ namespace Demo.MessageBox
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService;
-        private MainWindowViewModel viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowViewModel(dialogService.Object);
-        }
-
         [Test]
         public void ShowMessageBoxWithMessage()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock =>
                     mock.ShowMessageBox(
@@ -44,6 +37,9 @@ namespace Demo.MessageBox
         public void ShowMessageBoxWithCaption()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock =>
                     mock.ShowMessageBox(
@@ -66,6 +62,9 @@ namespace Demo.MessageBox
         public void ShowMessageBoxWithButton()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock =>
                     mock.ShowMessageBox(
@@ -88,6 +87,9 @@ namespace Demo.MessageBox
         public void ShowMessageBoxWithIcon()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock =>
                     mock.ShowMessageBox(
@@ -110,6 +112,9 @@ namespace Demo.MessageBox
         public void ShowMessageBoxWithDefaultResult()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock =>
                     mock.ShowMessageBox(

--- a/samples/wpf/Demo.MessageBox.Test/ScreenObjects/MainScreen.cs
+++ b/samples/wpf/Demo.MessageBox.Test/ScreenObjects/MainScreen.cs
@@ -8,57 +8,57 @@ namespace Demo.MessageBox.ScreenObjects
     public class MainScreen : AppScreen
     {
         [AutomationId("1k7d1Nm8MkOYK5qGrdVX4Q")]
-        private readonly Button messageBoxWithMessageButton = null;
+        private readonly Button? messageBoxWithMessageButton = null;
 
         [AutomationId("EvNqZT9tYkuNzKDDrLJ8Yw")]
-        private readonly Button messageBoxWithCaptionButton = null;
+        private readonly Button? messageBoxWithCaptionButton = null;
 
         [AutomationId("FWGzBkom5ESJz_p7KCPKqQ")]
-        private readonly Button messageBoxWithButtonsButton = null;
+        private readonly Button? messageBoxWithButtonsButton = null;
 
         [AutomationId("SapYi2J7bkiJ1z1GWwOZAQ")]
-        private readonly Button messageBoxWithIconButton = null;
+        private readonly Button? messageBoxWithIconButton = null;
 
         [AutomationId("sUjm2_m1LUGWso8S2Us5ow")]
-        private readonly Button messageBoxWithDefaultResultButton = null;
+        private readonly Button? messageBoxWithDefaultResultButton = null;
 
         [AutomationId("kT3_ZUZfsEK1QdZ2jBfuIQ")]
-        private readonly Label confirmation = null;
+        private readonly Label? confirmation = null;
 
         public MainScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
         {
         }
 
-        public virtual string Confirmation => confirmation.Text;
+        public virtual string? Confirmation => confirmation?.Text;
 
         public virtual MessageBoxScreen ClickMessageBoxWithMessage()
         {
-            messageBoxWithMessageButton.Click();
+            messageBoxWithMessageButton!.Click();
             return new MessageBoxScreen(Window.MessageBox(string.Empty), ScreenRepository);
         }
 
         public virtual MessageBoxScreen ClickMessageBoxWithCaption()
         {
-            messageBoxWithCaptionButton.Click();
+            messageBoxWithCaptionButton!.Click();
             return new MessageBoxScreen(Window.MessageBox("This Is The Caption"), ScreenRepository);
         }
 
         public virtual MessageBoxScreen ClickMessageBoxWithButtons()
         {
-            messageBoxWithButtonsButton.Click();
+            messageBoxWithButtonsButton!.Click();
             return new MessageBoxScreen(Window.MessageBox("This Is The Caption"), ScreenRepository);
         }
 
         public virtual MessageBoxScreen ClickMessageBoxWithIcon()
         {
-            messageBoxWithIconButton.Click();
+            messageBoxWithIconButton!.Click();
             return new MessageBoxScreen(Window.MessageBox("This Is The Caption"), ScreenRepository);
         }
 
         public virtual MessageBoxScreen ClickMessageBoxWithDefaultResult()
         {
-            messageBoxWithDefaultResultButton.Click();
+            messageBoxWithDefaultResultButton!.Click();
             return new MessageBoxScreen(Window.MessageBox("This Is The Caption"), ScreenRepository);
         }
     }

--- a/samples/wpf/Demo.MessageBox/Demo.MessageBox.csproj
+++ b/samples/wpf/Demo.MessageBox/Demo.MessageBox.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.MessageBox</RootNamespace>
     <AssemblyName>Demo.MessageBox</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.MessageBox/MainWindowViewModel.cs
+++ b/samples/wpf/Demo.MessageBox/MainWindowViewModel.cs
@@ -11,7 +11,7 @@ namespace Demo.MessageBox
     {
         private readonly IDialogService dialogService;
 
-        private string confirmation;
+        private string? confirmation;
         
         public MainWindowViewModel(IDialogService dialogService)
         {
@@ -34,7 +34,7 @@ namespace Demo.MessageBox
 
         public ICommand ShowMessageBoxWithDefaultResultCommand { get; }
 
-        public string Confirmation
+        public string? Confirmation
         {
             get => confirmation;
             private set => SetProperty(ref confirmation, value);

--- a/samples/wpf/Demo.ModalCustomDialog.Test/AddTextCustomDialogViewModelTest.cs
+++ b/samples/wpf/Demo.ModalCustomDialog.Test/AddTextCustomDialogViewModelTest.cs
@@ -5,21 +5,16 @@ namespace Demo.ModalCustomDialog
     [TestFixture]
     public class AddTextCustomDialogViewModelTest
     {
-        private AddTextCustomDialogViewModel viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            viewModel = new AddTextCustomDialogViewModel();
-        }
-
         [TestCase("Some text", true)]
         [TestCase("", null)]
         [TestCase(null, null)]
         public void Ok(string text, bool? expectedDialogResult)
         {
             // Arrange
-            viewModel.Text = text;
+            var viewModel = new AddTextCustomDialogViewModel
+            {
+                Text = text
+            };
 
             // Act
             viewModel.OkCommand.Execute(null);

--- a/samples/wpf/Demo.ModalCustomDialog.Test/Demo.ModalCustomDialog.Test.csproj
+++ b/samples/wpf/Demo.ModalCustomDialog.Test/Demo.ModalCustomDialog.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.ModalCustomDialog</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.ModalCustomDialog\Demo.ModalCustomDialog.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.ModalCustomDialog.Test/Features/AddTextSteps.cs
+++ b/samples/wpf/Demo.ModalCustomDialog.Test/Features/AddTextSteps.cs
@@ -13,7 +13,7 @@ namespace Demo.ModalCustomDialog.Features
     [Binding]
     public class AddTextSteps : FeatureSteps<MainScreen>
     {
-        private AddTextScreen addTextScreen;
+        private AddTextScreen? addTextScreen;
 
         protected override Application LaunchApplication()
         {
@@ -27,49 +27,49 @@ namespace Demo.ModalCustomDialog.Features
 
         protected override MainScreen GetMainScreen(ScreenRepository screenRepository)
         {
-            return ScreenRepository.Get<MainScreen>("Demo - Modal Custom Dialog", InitializeOption.NoCache);
+            return ScreenRepository!.Get<MainScreen>("Demo - Modal Custom Dialog", InitializeOption.NoCache);
         }
 
         [Given("dialog is shown using the dialog type locator")]
         public void ShowDialogUsingDialogTypeLocator()
         {
-            addTextScreen = MainScreen.ClickAddTextUsingDialogTypeLocator();
+            addTextScreen = MainScreen!.ClickAddTextUsingDialogTypeLocator();
         }
 
         [Given("dialog is shown by specifying dialog type")]
         public void ShowDialogBySpecifyingType()
         {
-            addTextScreen = MainScreen.ClickAddTextBySpecifyingDialogType();
+            addTextScreen = MainScreen!.ClickAddTextBySpecifyingDialogType();
         }
 
         [When(@"I enter the text (.*)")]
         public void Enter(string text)
         {
-            addTextScreen.Text = text;
+            addTextScreen!.Text = text;
         }
 
         [When("accept")]
         public void Accept()
         {
-            addTextScreen.ClickOK();
+            addTextScreen!.ClickOK();
         }
 
         [When("abort")]
         public void Abort()
         {
-            addTextScreen.ClickCancel();
+            addTextScreen!.ClickCancel();
         }
 
         [Then("the list of texts should contain (.*)")]
         public void VerifyListContains(string text)
         {
-            CollectionAssert.AreEqual(new[] { text }, MainScreen.Texts);
+            CollectionAssert.AreEqual(new[] { text }, MainScreen!.Texts);
         }
 
         [Then("the list of texts should be empty")]
         public void VerifyListIsEmpty()
         {
-            CollectionAssert.AreEqual(new string[0], MainScreen.Texts);
+            CollectionAssert.AreEqual(new string[0], MainScreen!.Texts);
         }
     }
 }

--- a/samples/wpf/Demo.ModalCustomDialog.Test/MainWindowViewModelTest.cs
+++ b/samples/wpf/Demo.ModalCustomDialog.Test/MainWindowViewModelTest.cs
@@ -8,20 +8,13 @@ namespace Demo.ModalCustomDialog
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService; 
-        private MainWindowViewModel viewModel;
-        
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowViewModel(dialogService.Object);
-        }
-
         [Test]
         public void ImplicitAddTextSuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowDialog(viewModel, It.IsAny<AddTextCustomDialogViewModel>()))
                 .Returns(true)
@@ -44,6 +37,9 @@ namespace Demo.ModalCustomDialog
         public void ImplicitAddTextUnsuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowDialog(viewModel, It.IsAny<AddTextCustomDialogViewModel>()))
                 .Returns(false);
@@ -59,6 +55,9 @@ namespace Demo.ModalCustomDialog
         public void ExplicitAddTextSuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowCustomDialog<AddTextCustomDialog>(viewModel, It.IsAny<AddTextCustomDialogViewModel>()))
                 .Returns(true)
@@ -81,6 +80,9 @@ namespace Demo.ModalCustomDialog
         public void ExplicitAddTextUnsuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowCustomDialog<AddTextCustomDialog>(viewModel, It.IsAny<AddTextCustomDialogViewModel>()))
                 .Returns(false);

--- a/samples/wpf/Demo.ModalCustomDialog.Test/ScreenObjects/AddTextScreen.cs
+++ b/samples/wpf/Demo.ModalCustomDialog.Test/ScreenObjects/AddTextScreen.cs
@@ -8,13 +8,13 @@ namespace Demo.ModalCustomDialog.ScreenObjects
     public class AddTextScreen : AppScreen
     {
         [AutomationId("Csl8dP93gUGQLj7rVZxDAg")]
-        private readonly TextBox text = null;
+        private readonly TextBox? text = null;
 
         [AutomationId("eyRW_87u20qR7QTCypm2RQ")]
-        private readonly Button okButton = null;
+        private readonly Button? okButton = null;
 
         [AutomationId("I91auHr_EECzhSZyIfvvzQ")]
-        private readonly Button cancelButton = null;
+        private readonly Button? cancelButton = null;
 
         public AddTextScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
@@ -23,11 +23,11 @@ namespace Demo.ModalCustomDialog.ScreenObjects
 
         public virtual string Text
         {
-            set => text.Text = value;
+            set => text!.Text = value;
         }
 
-        public virtual void ClickOK() => okButton.Click();
+        public virtual void ClickOK() => okButton!.Click();
 
-        public virtual void ClickCancel() => cancelButton.Click();
+        public virtual void ClickCancel() => cancelButton!.Click();
     }
 }

--- a/samples/wpf/Demo.ModalCustomDialog.Test/ScreenObjects/MainScreen.cs
+++ b/samples/wpf/Demo.ModalCustomDialog.Test/ScreenObjects/MainScreen.cs
@@ -12,13 +12,13 @@ namespace Demo.ModalCustomDialog.ScreenObjects
     public class MainScreen : AppScreen
     {
         [AutomationId("Vfkrmkr640yWmoMTKUWIbQ")]
-        private readonly ListBox texts = null;
+        private readonly ListBox? texts = null;
 
         [AutomationId("FHE_oyWqBEq_9TPaU1yPTQ")]
-        private readonly Button addTextUsingDialogTypeLocatorButton = null;
+        private readonly Button? addTextUsingDialogTypeLocatorButton = null;
 
         [AutomationId("Dq9ZjnVdFESxu8StkQ8jMw")]
-        private readonly Button addTextBySpecifyingDialogTypeButton = null;
+        private readonly Button? addTextBySpecifyingDialogTypeButton = null;
 
         public MainScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
@@ -27,18 +27,18 @@ namespace Demo.ModalCustomDialog.ScreenObjects
 
         public virtual IEnumerable<string> Texts
         {
-            get { return texts.Items.Select(item => item.Text); }
+            get { return texts!.Items.Select(item => item.Text); }
         }
 
         public virtual AddTextScreen ClickAddTextUsingDialogTypeLocator()
         {
-            addTextUsingDialogTypeLocatorButton.Click();
+            addTextUsingDialogTypeLocatorButton!.Click();
             return ScreenRepository.GetModal<AddTextScreen>("Add Text", Window, InitializeOption.NoCache);
         }
 
         public virtual AddTextScreen ClickAddTextBySpecifyingDialogType()
         {
-            addTextBySpecifyingDialogTypeButton.Click();
+            addTextBySpecifyingDialogTypeButton!.Click();
             return ScreenRepository.GetModal<AddTextScreen>("Add Text", Window, InitializeOption.NoCache);
         }
     }

--- a/samples/wpf/Demo.ModalCustomDialog/AddTextCustomDialogViewModel.cs
+++ b/samples/wpf/Demo.ModalCustomDialog/AddTextCustomDialogViewModel.cs
@@ -7,7 +7,7 @@ namespace Demo.ModalCustomDialog
 {
     public class AddTextCustomDialogViewModel : ObservableObject, IModalDialogViewModel
     {
-        private string text;
+        private string? text;
         private bool? dialogResult;
 
         public AddTextCustomDialogViewModel()
@@ -15,7 +15,7 @@ namespace Demo.ModalCustomDialog
             OkCommand = new RelayCommand(Ok);
         }
 
-        public string Text
+        public string? Text
         {
             get => text;
             set => SetProperty(ref text, value);

--- a/samples/wpf/Demo.ModalCustomDialog/Demo.ModalCustomDialog.csproj
+++ b/samples/wpf/Demo.ModalCustomDialog/Demo.ModalCustomDialog.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.ModalCustomDialog</RootNamespace>
     <AssemblyName>Demo.ModalCustomDialog</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.ModalCustomDialog/MainWindowViewModel.cs
+++ b/samples/wpf/Demo.ModalCustomDialog/MainWindowViewModel.cs
@@ -42,7 +42,7 @@ namespace Demo.ModalCustomDialog
             bool? success = showDialog(dialogViewModel);
             if (success == true)
             {
-                Texts.Add(dialogViewModel.Text);
+                Texts.Add(dialogViewModel.Text!);
             }
         }
     }

--- a/samples/wpf/Demo.ModalDialog.Test/AddTextDialogViewModelTest.cs
+++ b/samples/wpf/Demo.ModalDialog.Test/AddTextDialogViewModelTest.cs
@@ -5,21 +5,16 @@ namespace Demo.ModalDialog
     [TestFixture]
     public class AddTextDialogViewModelTest
     {
-        private AddTextDialogViewModel viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            viewModel = new AddTextDialogViewModel();
-        }
-
         [TestCase("Some text", true)]
         [TestCase("", null)]
         [TestCase(null, null)]
         public void Ok(string text, bool? expectedDialogResult)
         {
             // Arrange
-            viewModel.Text = text;
+            var viewModel = new AddTextDialogViewModel
+            {
+                Text = text
+            };
 
             // Act
             viewModel.OkCommand.Execute(null);

--- a/samples/wpf/Demo.ModalDialog.Test/Demo.ModalDialog.Test.csproj
+++ b/samples/wpf/Demo.ModalDialog.Test/Demo.ModalDialog.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.ModalDialog</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.ModalDialog\Demo.ModalDialog.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.ModalDialog.Test/Features/AddTextSteps.cs
+++ b/samples/wpf/Demo.ModalDialog.Test/Features/AddTextSteps.cs
@@ -13,7 +13,7 @@ namespace Demo.ModalDialog.Features
     [Binding]
     public class AddTextSteps : FeatureSteps<MainScreen>
     {
-        private AddTextScreen addTextScreen;
+        private AddTextScreen? addTextScreen;
 
         protected override Application LaunchApplication()
         {
@@ -27,49 +27,49 @@ namespace Demo.ModalDialog.Features
 
         protected override MainScreen GetMainScreen(ScreenRepository screenRepository)
         {
-            return ScreenRepository.Get<MainScreen>("Demo - Modal Dialog", InitializeOption.NoCache);
+            return ScreenRepository!.Get<MainScreen>("Demo - Modal Dialog", InitializeOption.NoCache);
         }
 
         [Given("dialog is shown using the dialog type locator")]
         public void ShowDialogUsingDialogTypeLocator()
         {
-            addTextScreen = MainScreen.ClickAddTextUsingDialogTypeLocator();
+            addTextScreen = MainScreen!.ClickAddTextUsingDialogTypeLocator();
         }
 
         [Given("dialog is shown by specifying dialog type")]
         public void ShowDialogBySpecifyingType()
         {
-            addTextScreen = MainScreen.ClickAddTextBySpecifyingDialogType();
+            addTextScreen = MainScreen!.ClickAddTextBySpecifyingDialogType();
         }
 
         [When(@"I enter the text (.*)")]
         public void Enter(string text)
         {
-            addTextScreen.Text = text;
+            addTextScreen!.Text = text;
         }
 
         [When("accept")]
         public void Accept()
         {
-            addTextScreen.ClickOK();
+            addTextScreen!.ClickOK();
         }
 
         [When("abort")]
         public void Abort()
         {
-            addTextScreen.ClickCancel();
+            addTextScreen!.ClickCancel();
         }
 
         [Then("the list of texts should contain (.*)")]
         public void VerifyListContains(string text)
         {
-            CollectionAssert.AreEqual(new[] { text }, MainScreen.Texts);
+            CollectionAssert.AreEqual(new[] { text }, MainScreen!.Texts);
         }
 
         [Then("the list of texts should be empty")]
         public void VerifyListIsEmpty()
         {
-            CollectionAssert.AreEqual(new string[0], MainScreen.Texts);
+            CollectionAssert.AreEqual(new string[0], MainScreen!.Texts);
         }
     }
 }

--- a/samples/wpf/Demo.ModalDialog.Test/MainWindowViewModelTest.cs
+++ b/samples/wpf/Demo.ModalDialog.Test/MainWindowViewModelTest.cs
@@ -8,20 +8,13 @@ namespace Demo.ModalDialog
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService; 
-        private MainWindowViewModel viewModel;
-        
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowViewModel(dialogService.Object);
-        }
-
         [Test]
         public void ImplicitAddTextSuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowDialog(viewModel, It.IsAny<AddTextDialogViewModel>()))
                 .Returns(true)
@@ -44,6 +37,9 @@ namespace Demo.ModalDialog
         public void ImplicitAddTextUnsuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowDialog(viewModel, It.IsAny<AddTextDialogViewModel>()))
                 .Returns(false);
@@ -59,6 +55,9 @@ namespace Demo.ModalDialog
         public void ExplicitAddTextSuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowDialog<AddTextDialog>(viewModel, It.IsAny<AddTextDialogViewModel>()))
                 .Returns(true)
@@ -81,6 +80,9 @@ namespace Demo.ModalDialog
         public void ExplicitAddTextUnsuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowDialog<AddTextDialog>(viewModel, It.IsAny<AddTextDialogViewModel>()))
                 .Returns(false);

--- a/samples/wpf/Demo.ModalDialog.Test/ScreenObjects/AddTextScreen.cs
+++ b/samples/wpf/Demo.ModalDialog.Test/ScreenObjects/AddTextScreen.cs
@@ -8,13 +8,13 @@ namespace Demo.ModalDialog.ScreenObjects
     public class AddTextScreen : AppScreen
     {
         [AutomationId("Csl8dP93gUGQLj7rVZxDAg")]
-        private readonly TextBox text = null;
+        private readonly TextBox? text = null;
 
         [AutomationId("eyRW_87u20qR7QTCypm2RQ")]
-        private readonly Button okButton = null;
+        private readonly Button? okButton = null;
 
         [AutomationId("I91auHr_EECzhSZyIfvvzQ")]
-        private readonly Button cancelButton = null;
+        private readonly Button? cancelButton = null;
 
         public AddTextScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
@@ -23,11 +23,11 @@ namespace Demo.ModalDialog.ScreenObjects
 
         public virtual string Text
         {
-            set => text.Text = value;
+            set => text!.Text = value;
         }
 
-        public virtual void ClickOK() => okButton.Click();
+        public virtual void ClickOK() => okButton!.Click();
 
-        public virtual void ClickCancel() => cancelButton.Click();
+        public virtual void ClickCancel() => cancelButton!.Click();
     }
 }

--- a/samples/wpf/Demo.ModalDialog.Test/ScreenObjects/MainScreen.cs
+++ b/samples/wpf/Demo.ModalDialog.Test/ScreenObjects/MainScreen.cs
@@ -12,13 +12,13 @@ namespace Demo.ModalDialog.ScreenObjects
     public class MainScreen : AppScreen
     {
         [AutomationId("Vfkrmkr640yWmoMTKUWIbQ")]
-        private readonly ListBox texts = null;
+        private readonly ListBox? texts = null;
 
         [AutomationId("FHE_oyWqBEq_9TPaU1yPTQ")]
-        private readonly Button addTextUsingDialogTypeLocatorButton = null;
+        private readonly Button? addTextUsingDialogTypeLocatorButton = null;
 
         [AutomationId("Dq9ZjnVdFESxu8StkQ8jMw")]
-        private readonly Button addTextBySpecifyingDialogTypeButton = null;
+        private readonly Button? addTextBySpecifyingDialogTypeButton = null;
 
         public MainScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
@@ -27,18 +27,18 @@ namespace Demo.ModalDialog.ScreenObjects
 
         public virtual IEnumerable<string> Texts
         {
-            get { return texts.Items.Select(item => item.Text); }
+            get { return texts!.Items.Select(item => item.Text); }
         }
 
         public virtual AddTextScreen ClickAddTextUsingDialogTypeLocator()
         {
-            addTextUsingDialogTypeLocatorButton.Click();
+            addTextUsingDialogTypeLocatorButton!.Click();
             return ScreenRepository.GetModal<AddTextScreen>("Add Text", Window, InitializeOption.NoCache);
         }
 
         public virtual AddTextScreen ClickAddTextBySpecifyingDialogType()
         {
-            addTextBySpecifyingDialogTypeButton.Click();
+            addTextBySpecifyingDialogTypeButton!.Click();
             return ScreenRepository.GetModal<AddTextScreen>("Add Text", Window, InitializeOption.NoCache);
         }
     }

--- a/samples/wpf/Demo.ModalDialog/AddTextDialogViewModel.cs
+++ b/samples/wpf/Demo.ModalDialog/AddTextDialogViewModel.cs
@@ -7,7 +7,7 @@ namespace Demo.ModalDialog
 {
     public class AddTextDialogViewModel : ObservableObject, IModalDialogViewModel
     {
-        private string text;
+        private string? text;
         private bool? dialogResult;
 
         public AddTextDialogViewModel()
@@ -15,7 +15,7 @@ namespace Demo.ModalDialog
             OkCommand = new RelayCommand(Ok);
         }
 
-        public string Text
+        public string? Text
         {
             get => text;
             set => SetProperty(ref text, value);

--- a/samples/wpf/Demo.ModalDialog/Demo.ModalDialog.csproj
+++ b/samples/wpf/Demo.ModalDialog/Demo.ModalDialog.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.ModalDialog</RootNamespace>
     <AssemblyName>Demo.ModalDialog</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.ModalDialog/MainWindowViewModel.cs
+++ b/samples/wpf/Demo.ModalDialog/MainWindowViewModel.cs
@@ -42,7 +42,7 @@ namespace Demo.ModalDialog
             bool? success = showDialog(dialogViewModel);
             if (success == true)
             {
-                Texts.Add(dialogViewModel.Text);
+                Texts.Add(dialogViewModel.Text!);
             }
         }
     }

--- a/samples/wpf/Demo.NonModalCustomDialog.Test/Demo.NonModalCustomDialog.Test.csproj
+++ b/samples/wpf/Demo.NonModalCustomDialog.Test/Demo.NonModalCustomDialog.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.NonModalCustomDialog</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.NonModalCustomDialog\Demo.NonModalCustomDialog.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.NonModalCustomDialog.Test/Features/ShowCurrentTimeSteps.cs
+++ b/samples/wpf/Demo.NonModalCustomDialog.Test/Features/ShowCurrentTimeSteps.cs
@@ -13,7 +13,7 @@ namespace Demo.NonModalCustomDialog.Features
     [Binding]
     public class ShowCurrentTimeSteps : FeatureSteps<MainScreen>
     {
-        private CurrentTimeScreen currentTimeScreen;
+        private CurrentTimeScreen? currentTimeScreen;
 
         protected override Application LaunchApplication()
         {
@@ -27,25 +27,25 @@ namespace Demo.NonModalCustomDialog.Features
 
         protected override MainScreen GetMainScreen(ScreenRepository screenRepository)
         {
-            return ScreenRepository.Get<MainScreen>("Demo - Non-Modal Custom Dialog", InitializeOption.NoCache);
+            return ScreenRepository!.Get<MainScreen>("Demo - Non-Modal Custom Dialog", InitializeOption.NoCache);
         }
 
         [When("dialog is shown using the dialog type locator")]
         public void WhenDialogIsShownUsingTheDialogTypeLocator()
         {
-            currentTimeScreen = MainScreen.ClickShowCurrentTimeUsingDialogTypeLocator();
+            currentTimeScreen = MainScreen!.ClickShowCurrentTimeUsingDialogTypeLocator();
         }
 
         [When("dialog is shown by specifying dialog type")]
         public void WhenDialogIsShownBySpecifyingDialogType()
         {
-            currentTimeScreen = MainScreen.ClickShowCurrentTimeBySpecifyingDialogType();
+            currentTimeScreen = MainScreen!.ClickShowCurrentTimeBySpecifyingDialogType();
         }
 
         [Then("the current time should be displayed")]
         public void VerifyCurrentTimeIsDisplayed()
         {
-            Assert.That(currentTimeScreen.CurrentTimeVisible, Is.True);
+            Assert.That(currentTimeScreen!.CurrentTimeVisible, Is.True);
         }
     }
 }

--- a/samples/wpf/Demo.NonModalCustomDialog.Test/MainWindowViewModelTest.cs
+++ b/samples/wpf/Demo.NonModalCustomDialog.Test/MainWindowViewModelTest.cs
@@ -7,20 +7,13 @@ namespace Demo.NonModalCustomDialog
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService;
-        private MainWindowViewModel viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowViewModel(dialogService.Object);
-        }
-
         [Test]
         public void ImplicitShowCurrentTime()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.Show(viewModel, It.IsAny<CurrentTimeCustomDialogViewModel>()))
                 .Verifiable();
@@ -36,6 +29,9 @@ namespace Demo.NonModalCustomDialog
         public void ExplicitShowCurrentTime()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowCustom<CurrentTimeCustomDialog>(It.IsAny<MainWindowViewModel>(), It.IsAny<CurrentTimeCustomDialogViewModel>()))
                 .Verifiable();

--- a/samples/wpf/Demo.NonModalCustomDialog.Test/ScreenObjects/CurrentTimeScreen.cs
+++ b/samples/wpf/Demo.NonModalCustomDialog.Test/ScreenObjects/CurrentTimeScreen.cs
@@ -8,13 +8,13 @@ namespace Demo.NonModalCustomDialog.ScreenObjects
     public class CurrentTimeScreen : AppScreen
     {
         [AutomationId("n_Mu0TdFak-4VJD8RosMEQ")]
-        private readonly Label currentTime = null;
+        private readonly Label? currentTime = null;
 
         public CurrentTimeScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
         {
         }
 
-        public virtual bool CurrentTimeVisible => currentTime.Visible;
+        public virtual bool CurrentTimeVisible => currentTime!.Visible;
     }
 }

--- a/samples/wpf/Demo.NonModalCustomDialog.Test/ScreenObjects/MainScreen.cs
+++ b/samples/wpf/Demo.NonModalCustomDialog.Test/ScreenObjects/MainScreen.cs
@@ -9,10 +9,10 @@ namespace Demo.NonModalCustomDialog.ScreenObjects
     public class MainScreen : AppScreen
     {
         [AutomationId("6U4UYFLlnUKOBx26wvyDOg")]
-        private readonly Button showCurrentTimeUsingDialogTypeLocatorButton = null;
+        private readonly Button? showCurrentTimeUsingDialogTypeLocatorButton = null;
 
         [AutomationId("yp7kt1tOeEqE5y2KmylhGQ")]
-        private readonly Button showCurrentTimeBySpecifyingDialogTypeButton = null;
+        private readonly Button? showCurrentTimeBySpecifyingDialogTypeButton = null;
 
         public MainScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
@@ -21,13 +21,13 @@ namespace Demo.NonModalCustomDialog.ScreenObjects
 
         public virtual CurrentTimeScreen ClickShowCurrentTimeUsingDialogTypeLocator()
         {
-            showCurrentTimeUsingDialogTypeLocatorButton.Click();
+            showCurrentTimeUsingDialogTypeLocatorButton!.Click();
             return ScreenRepository.GetModal<CurrentTimeScreen>("Current Time", Window, InitializeOption.NoCache);
         }
 
         public virtual CurrentTimeScreen ClickShowCurrentTimeBySpecifyingDialogType()
         {
-            showCurrentTimeBySpecifyingDialogTypeButton.Click();
+            showCurrentTimeBySpecifyingDialogTypeButton!.Click();
             return ScreenRepository.GetModal<CurrentTimeScreen>("Current Time", Window, InitializeOption.NoCache);
         }
     }

--- a/samples/wpf/Demo.NonModalCustomDialog/CurrentTimeCustomDialogViewModel.cs
+++ b/samples/wpf/Demo.NonModalCustomDialog/CurrentTimeCustomDialogViewModel.cs
@@ -9,7 +9,7 @@ namespace Demo.NonModalCustomDialog
     public class CurrentTimeCustomDialogViewModel : ObservableObject
     {
         // ReSharper disable once NotAccessedField.Local
-        private DispatcherTimer timer;
+        private DispatcherTimer? timer;
 
         public CurrentTimeCustomDialogViewModel()
         {
@@ -29,7 +29,7 @@ namespace Demo.NonModalCustomDialog
                 Dispatcher.CurrentDispatcher);
         }
 
-        private void OnTick(object sender, EventArgs e)
+        private void OnTick(object? sender, EventArgs e)
         {
             OnPropertyChanged(nameof(CurrentTime));
         }

--- a/samples/wpf/Demo.NonModalCustomDialog/Demo.NonModalCustomDialog.csproj
+++ b/samples/wpf/Demo.NonModalCustomDialog/Demo.NonModalCustomDialog.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.NonModalCustomDialog</RootNamespace>
     <AssemblyName>Demo.NonModalCustomDialog</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.NonModalDialog.Test/Demo.NonModalDialog.Test.csproj
+++ b/samples/wpf/Demo.NonModalDialog.Test/Demo.NonModalDialog.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.NonModalDialog</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.NonModalDialog\Demo.NonModalDialog.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.NonModalDialog.Test/Features/ShowCurrentTimeSteps.cs
+++ b/samples/wpf/Demo.NonModalDialog.Test/Features/ShowCurrentTimeSteps.cs
@@ -13,7 +13,7 @@ namespace Demo.NonModalDialog.Features
     [Binding]
     public class ShowCurrentTimeSteps : FeatureSteps<MainScreen>
     {
-        private CurrentTimeScreen currentTimeScreen;
+        private CurrentTimeScreen? currentTimeScreen;
 
         protected override Application LaunchApplication()
         {
@@ -27,25 +27,25 @@ namespace Demo.NonModalDialog.Features
 
         protected override MainScreen GetMainScreen(ScreenRepository screenRepository)
         {
-            return ScreenRepository.Get<MainScreen>("Demo - Non-Modal Dialog", InitializeOption.NoCache);
+            return ScreenRepository!.Get<MainScreen>("Demo - Non-Modal Dialog", InitializeOption.NoCache);
         }
 
         [When("dialog is shown using the dialog type locator")]
         public void WhenDialogIsShownUsingTheDialogTypeLocator()
         {
-            currentTimeScreen = MainScreen.ClickShowCurrentTimeUsingDialogTypeLocator();
+            currentTimeScreen = MainScreen!.ClickShowCurrentTimeUsingDialogTypeLocator();
         }
 
         [When("dialog is shown by specifying dialog type")]
         public void WhenDialogIsShownBySpecifyingDialogType()
         {
-            currentTimeScreen = MainScreen.ClickShowCurrentTimeBySpecifyingDialogType();
+            currentTimeScreen = MainScreen!.ClickShowCurrentTimeBySpecifyingDialogType();
         }
 
         [Then("the current time should be displayed")]
         public void VerifyCurrentTimeIsDisplayed()
         {
-            Assert.That(currentTimeScreen.CurrentTimeVisible, Is.True);
+            Assert.That(currentTimeScreen!.CurrentTimeVisible, Is.True);
         }
     }
 }

--- a/samples/wpf/Demo.NonModalDialog.Test/MainWindowViewModelTest.cs
+++ b/samples/wpf/Demo.NonModalDialog.Test/MainWindowViewModelTest.cs
@@ -7,20 +7,13 @@ namespace Demo.NonModalDialog
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService;
-        private MainWindowViewModel viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowViewModel(dialogService.Object);
-        }
-
         [Test]
         public void ImplicitShowCurrentTime()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.Show(viewModel, It.IsAny<CurrentTimeDialogViewModel>()))
                 .Verifiable();
@@ -36,6 +29,9 @@ namespace Demo.NonModalDialog
         public void ExplicitShowCurrentTime()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.Show<CurrentTimeDialog>(It.IsAny<MainWindowViewModel>(), It.IsAny<CurrentTimeDialogViewModel>()))
                 .Verifiable();

--- a/samples/wpf/Demo.NonModalDialog.Test/ScreenObjects/CurrentTimeScreen.cs
+++ b/samples/wpf/Demo.NonModalDialog.Test/ScreenObjects/CurrentTimeScreen.cs
@@ -8,13 +8,13 @@ namespace Demo.NonModalDialog.ScreenObjects
     public class CurrentTimeScreen : AppScreen
     {
         [AutomationId("n_Mu0TdFak-4VJD8RosMEQ")]
-        private readonly Label currentTime = null;
+        private readonly Label? currentTime = null;
 
         public CurrentTimeScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
         {
         }
 
-        public virtual bool CurrentTimeVisible => currentTime.Visible;
+        public virtual bool CurrentTimeVisible => currentTime!.Visible;
     }
 }

--- a/samples/wpf/Demo.NonModalDialog.Test/ScreenObjects/MainScreen.cs
+++ b/samples/wpf/Demo.NonModalDialog.Test/ScreenObjects/MainScreen.cs
@@ -9,10 +9,10 @@ namespace Demo.NonModalDialog.ScreenObjects
     public class MainScreen : AppScreen
     {
         [AutomationId("6U4UYFLlnUKOBx26wvyDOg")]
-        private readonly Button showCurrentTimeUsingDialogTypeLocatorButton = null;
+        private readonly Button? showCurrentTimeUsingDialogTypeLocatorButton = null;
 
         [AutomationId("yp7kt1tOeEqE5y2KmylhGQ")]
-        private readonly Button showCurrentTimeBySpecifyingDialogTypeButton = null;
+        private readonly Button? showCurrentTimeBySpecifyingDialogTypeButton = null;
 
         public MainScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
@@ -21,13 +21,13 @@ namespace Demo.NonModalDialog.ScreenObjects
 
         public virtual CurrentTimeScreen ClickShowCurrentTimeUsingDialogTypeLocator()
         {
-            showCurrentTimeUsingDialogTypeLocatorButton.Click();
+            showCurrentTimeUsingDialogTypeLocatorButton!.Click();
             return ScreenRepository.GetModal<CurrentTimeScreen>("Current Time", Window, InitializeOption.NoCache);
         }
 
         public virtual CurrentTimeScreen ClickShowCurrentTimeBySpecifyingDialogType()
         {
-            showCurrentTimeBySpecifyingDialogTypeButton.Click();
+            showCurrentTimeBySpecifyingDialogTypeButton!.Click();
             return ScreenRepository.GetModal<CurrentTimeScreen>("Current Time", Window, InitializeOption.NoCache);
         }
     }

--- a/samples/wpf/Demo.NonModalDialog/CurrentTimeDialogViewModel.cs
+++ b/samples/wpf/Demo.NonModalDialog/CurrentTimeDialogViewModel.cs
@@ -9,7 +9,7 @@ namespace Demo.NonModalDialog
     public class CurrentTimeDialogViewModel : ObservableObject
     {
         // ReSharper disable once NotAccessedField.Local
-        private DispatcherTimer timer;
+        private DispatcherTimer? timer;
 
         public CurrentTimeDialogViewModel()
         {
@@ -29,7 +29,7 @@ namespace Demo.NonModalDialog
                 Dispatcher.CurrentDispatcher);
         }
 
-        private void OnTick(object sender, EventArgs e)
+        private void OnTick(object? sender, EventArgs e)
         {
             OnPropertyChanged(nameof(CurrentTime));
         }

--- a/samples/wpf/Demo.NonModalDialog/Demo.NonModalDialog.csproj
+++ b/samples/wpf/Demo.NonModalDialog/Demo.NonModalDialog.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.NonModalDialog</RootNamespace>
     <AssemblyName>Demo.NonModalDialog</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.OpenFileDialog.Test/Demo.OpenFileDialog.Test.csproj
+++ b/samples/wpf/Demo.OpenFileDialog.Test/Demo.OpenFileDialog.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.OpenFileDialog</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.OpenFileDialog\Demo.OpenFileDialog.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.OpenFileDialog.Test/Features/OpenFileSteps.cs
+++ b/samples/wpf/Demo.OpenFileDialog.Test/Features/OpenFileSteps.cs
@@ -13,7 +13,7 @@ namespace Demo.OpenFileDialog.Features
     [Binding]
     public class OpenFileSteps : FeatureSteps<MainScreen>
     {
-        private OpenFileScreen openFileScreen;
+        private OpenFileScreen? openFileScreen;
 
         protected override Application LaunchApplication()
         {
@@ -27,38 +27,38 @@ namespace Demo.OpenFileDialog.Features
 
         protected override MainScreen GetMainScreen(ScreenRepository screenRepository)
         {
-            return ScreenRepository.Get<MainScreen>("Demo - Open File Dialog", InitializeOption.NoCache);
+            return ScreenRepository!.Get<MainScreen>("Demo - Open File Dialog", InitializeOption.NoCache);
         }
 
         [Given("I have selected to open a file")]
         public void OpenFile()
         {
-            openFileScreen = MainScreen.ClickOpen();
+            openFileScreen = MainScreen!.ClickOpen();
             openFileScreen.FileName = "OpenMe.txt";
         }
 
         [When("I press confirm")]
         public void Confirm()
         {
-            openFileScreen.ClickOpen();
+            openFileScreen!.ClickOpen();
         }
 
         [When("I cancel")]
         public void Cancel()
         {
-            openFileScreen.ClickCancel();
+            openFileScreen!.ClickCancel();
         }
 
         [Then("the file should be opened")]
         public void VerifyFileWasOpened()
         {
-            StringAssert.EndsWith("OpenMe.txt", MainScreen.FileName);
+            StringAssert.EndsWith("OpenMe.txt", MainScreen!.FileName);
         }
 
         [Then("the file should not be opened")]
         public void VerifyFileWasNotOpened()
         {
-            Assert.That(MainScreen.FileName, Is.Empty);
+            Assert.That(MainScreen!.FileName, Is.Empty);
         }
     }
 }

--- a/samples/wpf/Demo.OpenFileDialog.Test/MainWindowViewModelTest.cs
+++ b/samples/wpf/Demo.OpenFileDialog.Test/MainWindowViewModelTest.cs
@@ -9,20 +9,13 @@ namespace Demo.OpenFileDialog
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService;
-        private MainWindowViewModel viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowViewModel(dialogService.Object);
-        }
-
         [Test]
         public void OpenFileSuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowOpenFileDialog(viewModel, It.IsAny<OpenFileDialogSettings>()))
                 .Returns(true)
@@ -40,6 +33,9 @@ namespace Demo.OpenFileDialog
         public void OpenFileUnsuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowOpenFileDialog(viewModel, It.IsAny<OpenFileDialogSettings>()))
                 .Returns(false);

--- a/samples/wpf/Demo.OpenFileDialog.Test/ScreenObjects/MainScreen.cs
+++ b/samples/wpf/Demo.OpenFileDialog.Test/ScreenObjects/MainScreen.cs
@@ -9,21 +9,21 @@ namespace Demo.OpenFileDialog.ScreenObjects
     public class MainScreen : AppScreen
     {
         [AutomationId("cqkeItgI3UaZc-mQ6mYPAA")]
-        private readonly TextBox pathTextBox = null;
+        private readonly TextBox? pathTextBox = null;
 
         [AutomationId("MZ16xHTzYE2UP8S9vd-EGw")]
-        private readonly Button openButton = null;
+        private readonly Button? openButton = null;
 
         public MainScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
         {
         }
 
-        public virtual string FileName => pathTextBox.Text;
+        public virtual string FileName => pathTextBox!.Text;
 
         public virtual OpenFileScreen ClickOpen()
         {
-            openButton.Click();
+            openButton!.Click();
             return ScreenRepository.GetModal<OpenFileScreen>("This Is The Title", Window, InitializeOption.NoCache);
         }
     }

--- a/samples/wpf/Demo.OpenFileDialog/Demo.OpenFileDialog.csproj
+++ b/samples/wpf/Demo.OpenFileDialog/Demo.OpenFileDialog.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.OpenFileDialog</RootNamespace>
     <AssemblyName>Demo.OpenFileDialog</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.OpenFileDialog/MainWindowViewModel.cs
+++ b/samples/wpf/Demo.OpenFileDialog/MainWindowViewModel.cs
@@ -12,7 +12,7 @@ namespace Demo.OpenFileDialog
     {
         private readonly IDialogService dialogService;
 
-        private string path;
+        private string? path;
 
         public MainWindowViewModel(IDialogService dialogService)
         {
@@ -21,7 +21,7 @@ namespace Demo.OpenFileDialog
             OpenFileCommand = new RelayCommand(OpenFile);
         }
 
-        public string Path
+        public string? Path
         {
             get => path;
             private set => SetProperty(ref path, value);
@@ -34,7 +34,7 @@ namespace Demo.OpenFileDialog
             var settings = new OpenFileDialogSettings
             {
                 Title = "This Is The Title",
-                InitialDirectory = IOPath.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                InitialDirectory = IOPath.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
                 Filter = "Text Documents (*.txt)|*.txt|All Files (*.*)|*.*"
             };
 

--- a/samples/wpf/Demo.SaveFileDialog.Test/Demo.SaveFileDialog.Test.csproj
+++ b/samples/wpf/Demo.SaveFileDialog.Test/Demo.SaveFileDialog.Test.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
     <RootNamespace>Demo.SaveFileDialog</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\net\MvvmDialogs.csproj" />
     <ProjectReference Include="..\Demo.SaveFileDialog\Demo.SaveFileDialog.csproj" />
     <ProjectReference Include="..\TestBaseClasses\TestBaseClasses.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.5.30" />
   </ItemGroup>
+
 </Project>

--- a/samples/wpf/Demo.SaveFileDialog.Test/Features/SaveFileSteps.cs
+++ b/samples/wpf/Demo.SaveFileDialog.Test/Features/SaveFileSteps.cs
@@ -13,7 +13,7 @@ namespace Demo.SaveFileDialog.Features
     [Binding]
     public class SaveFileSteps : FeatureSteps<MainScreen>
     {
-        private SaveFileScreen saveFileScreen;
+        private SaveFileScreen? saveFileScreen;
 
         protected override Application LaunchApplication()
         {
@@ -27,38 +27,38 @@ namespace Demo.SaveFileDialog.Features
 
         protected override MainScreen GetMainScreen(ScreenRepository screenRepository)
         {
-            return ScreenRepository.Get<MainScreen>("Demo - Save File Dialog", InitializeOption.NoCache);
+            return ScreenRepository!.Get<MainScreen>("Demo - Save File Dialog", InitializeOption.NoCache);
         }
 
         [Given("I have selected to save a file")]
         public void SaveFile()
         {
-            saveFileScreen = MainScreen.ClickSave();
+            saveFileScreen = MainScreen!.ClickSave();
             saveFileScreen.FileName = "SaveMe.txt";
         }
 
         [When("I press confirm")]
         public void Confirm()
         {
-            saveFileScreen.ClickSave();
+            saveFileScreen!.ClickSave();
         }
 
         [When("I cancel")]
         public void Cancel()
         {
-            saveFileScreen.ClickCancel();
+            saveFileScreen!.ClickCancel();
         }
 
         [Then("the file should be saved")]
         public void VerifyFileWasSaved()
         {
-            StringAssert.EndsWith("SaveMe.txt", MainScreen.FileName);
+            StringAssert.EndsWith("SaveMe.txt", MainScreen!.FileName);
         }
 
         [Then("the file should not be saved")]
         public void VerifyFileWasNotSaved()
         {
-            Assert.That(MainScreen.FileName, Is.Empty);
+            Assert.That(MainScreen!.FileName, Is.Empty);
         }
     }
 }

--- a/samples/wpf/Demo.SaveFileDialog.Test/MainWindowViewModelTest.cs
+++ b/samples/wpf/Demo.SaveFileDialog.Test/MainWindowViewModelTest.cs
@@ -9,20 +9,13 @@ namespace Demo.SaveFileDialog
     [TestFixture]
     public class MainWindowViewModelTest
     {
-        private Mock<IDialogService> dialogService;
-        private MainWindowViewModel viewModel;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialogService = new Mock<IDialogService>();
-            viewModel = new MainWindowViewModel(dialogService.Object);
-        }
-
         [Test]
         public void SaveFileSuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowSaveFileDialog(viewModel, It.IsAny<SaveFileDialogSettings>()))
                 .Returns(true)
@@ -40,6 +33,9 @@ namespace Demo.SaveFileDialog
         public void OpenFileUnsuccessful()
         {
             // Arrange
+            var dialogService = new Mock<IDialogService>();
+            var viewModel = new MainWindowViewModel(dialogService.Object);
+
             dialogService
                 .Setup(mock => mock.ShowSaveFileDialog(viewModel, It.IsAny<SaveFileDialogSettings>()))
                 .Returns(false);

--- a/samples/wpf/Demo.SaveFileDialog.Test/ScreenObjects/MainScreen.cs
+++ b/samples/wpf/Demo.SaveFileDialog.Test/ScreenObjects/MainScreen.cs
@@ -9,21 +9,21 @@ namespace Demo.SaveFileDialog.ScreenObjects
     public class MainScreen : AppScreen
     {
         [AutomationId("-u3vcUdRMUaG4Af_kzSeZQ")]
-        private readonly TextBox pathTextBox = null;
+        private readonly TextBox? pathTextBox = null;
 
         [AutomationId("HstqC8HI9EOGiTfPA4_xag")]
-        private readonly Button saveButton = null;
+        private readonly Button? saveButton = null;
 
         public MainScreen(Window window, ScreenRepository screenRepository)
             : base(window, screenRepository)
         {
         }
 
-        public virtual string FileName => pathTextBox.Text;
+        public virtual string FileName => pathTextBox!.Text;
 
         public virtual SaveFileScreen ClickSave()
         {
-            saveButton.Click();
+            saveButton!.Click();
             return ScreenRepository.GetModal<SaveFileScreen>("This Is The Title", Window, InitializeOption.NoCache);
         }
     }

--- a/samples/wpf/Demo.SaveFileDialog/Demo.SaveFileDialog.csproj
+++ b/samples/wpf/Demo.SaveFileDialog/Demo.SaveFileDialog.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.SaveFileDialog</RootNamespace>
     <AssemblyName>Demo.SaveFileDialog</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/wpf/Demo.SaveFileDialog/MainWindowViewModel.cs
+++ b/samples/wpf/Demo.SaveFileDialog/MainWindowViewModel.cs
@@ -12,7 +12,7 @@ namespace Demo.SaveFileDialog
     {
         private readonly IDialogService dialogService;
 
-        private string path;
+        private string? path;
 
         public MainWindowViewModel(IDialogService dialogService)
         {
@@ -21,7 +21,7 @@ namespace Demo.SaveFileDialog
             SaveFileCommand = new RelayCommand(SaveFile);
         }
 
-        public string Path
+        public string? Path
         {
             get => path;
             private set => SetProperty(ref path, value);
@@ -34,7 +34,7 @@ namespace Demo.SaveFileDialog
             var settings = new SaveFileDialogSettings
             {
                 Title = "This Is The Title",
-                InitialDirectory = IOPath.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                InitialDirectory = IOPath.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
                 Filter = "Text Documents (*.txt)|*.txt|All Files (*.*)|*.*",
                 CheckFileExists = false
             };

--- a/samples/wpf/TestBaseClasses/Features/FeatureSteps.cs
+++ b/samples/wpf/TestBaseClasses/Features/FeatureSteps.cs
@@ -15,11 +15,11 @@ namespace TestBaseClasses.Features
     /// </summary>
     public abstract class FeatureSteps<T> where T : AppScreen
     {
-        protected Application Application { get; private set; }
+        protected Application? Application { get; private set; }
 
-        protected ScreenRepository ScreenRepository { get; private set; }
+        protected ScreenRepository? ScreenRepository { get; private set; }
 
-        protected T MainScreen { get; private set; }
+        protected T? MainScreen { get; private set; }
 
         [BeforeScenario]
         public void InitialBeforeScenario()

--- a/samples/wpf/TestBaseClasses/TestBaseClasses.csproj
+++ b/samples/wpf/TestBaseClasses/TestBaseClasses.csproj
@@ -1,11 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net472</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="SpecFlow.NUnit" Version="3.9.40" />
     <PackageReference Include="TestStack.White.ScreenObjects" Version="0.13.3" />
   </ItemGroup>
+
 </Project>

--- a/test/net/DialogTypeLocators/DialogTypeLocatorCacheTest.cs
+++ b/test/net/DialogTypeLocators/DialogTypeLocatorCacheTest.cs
@@ -6,17 +6,12 @@ namespace MvvmDialogs.DialogTypeLocators
     [TestFixture]
     public class DialogTypeLocatorCacheTest
     {
-        private DialogTypeLocatorCache cache;
-
-        [SetUp]
-        public void SetUp()
-        {
-            cache = new DialogTypeLocatorCache();
-        }
-
         [Test]
         public void Add()
         {
+            // Arrange
+            var cache = new DialogTypeLocatorCache();
+
             // Act
             cache.Add(typeof(TestDialogViewModel), typeof(TestDialog));
 
@@ -28,6 +23,7 @@ namespace MvvmDialogs.DialogTypeLocators
         public void AddSameTwice()
         {
             // Arrange
+            var cache = new DialogTypeLocatorCache();
             cache.Add(typeof(TestDialogViewModel), typeof(TestDialog));
 
             // Assert
@@ -38,10 +34,11 @@ namespace MvvmDialogs.DialogTypeLocators
         public void Get()
         {
             // Arrange
+            var cache = new DialogTypeLocatorCache();
             cache.Add(typeof(TestDialogViewModel), typeof(TestDialog));
 
             // Act
-            Type dialogType = cache.Get(typeof(TestDialogViewModel));
+            Type? dialogType = cache.Get(typeof(TestDialogViewModel));
 
             // Assert
             Assert.That(dialogType, Is.EqualTo(typeof(TestDialog)));
@@ -51,6 +48,7 @@ namespace MvvmDialogs.DialogTypeLocators
         public void Clear()
         {
             // Arrange
+            var cache = new DialogTypeLocatorCache();
             cache.Add(typeof(TestDialogViewModel), typeof(TestDialog));
 
             // Act

--- a/test/net/DialogTypeLocators/NamingConventionDialogTypeLocatorTest.cs
+++ b/test/net/DialogTypeLocators/NamingConventionDialogTypeLocatorTest.cs
@@ -8,11 +8,9 @@ namespace MvvmDialogs.DialogTypeLocators
     [TestFixture]
     public class NamingConventionDialogTypeLocatorTest
     {
-        private Assembly testAssembly;
-        private NamingConventionDialogTypeLocator dialogTypeLocator;
+        private readonly Assembly testAssembly;
 
-        [OneTimeSetUp]
-        public void OneTimeSetUp()
+        public NamingConventionDialogTypeLocatorTest()
         {
             NamingConventionDialogTypeLocator.Cache.Clear();
 
@@ -39,12 +37,6 @@ namespace MvvmDialogs.DialogTypeLocators
             testAssembly = assemblyBuilder.Build();
         }
 
-        [SetUp]
-        public void SetUp()
-        {
-            dialogTypeLocator = new NamingConventionDialogTypeLocator();
-        }
-
         [TestCase("TestAssembly.DialogViewModel", "TestAssembly.Dialog")]
         [TestCase("TestAssembly.ViewModels.DialogViewModel", "TestAssembly.Views.Dialog")]
         [TestCase("TestAssembly.ViewModels.Module.DialogViewModel", "TestAssembly.Views.Module.Dialog")]
@@ -52,6 +44,7 @@ namespace MvvmDialogs.DialogTypeLocators
         public void LocateDialogTypeSuccessful(string viewModelFullName, string viewFullName)
         {
             // Arrange
+            var dialogTypeLocator = new NamingConventionDialogTypeLocator();
             Type viewModelType = testAssembly.GetType(viewModelFullName);
             Assert.IsNotNull(viewModelType);
 
@@ -69,6 +62,7 @@ namespace MvvmDialogs.DialogTypeLocators
         public void LocateDialogTypeUnsuccessful(string viewModelFullName)
         {
             // Arrange
+            var dialogTypeLocator = new NamingConventionDialogTypeLocator();
             Type viewModelType = testAssembly.GetType(viewModelFullName);
             Assert.IsNotNull(viewModelType);
 

--- a/test/net/FrameworkDialogs/FolderBrowser/FolderBrowserDialogSettingsSyncTest.cs
+++ b/test/net/FrameworkDialogs/FolderBrowser/FolderBrowserDialogSettingsSyncTest.cs
@@ -7,22 +7,14 @@ namespace MvvmDialogs.FrameworkDialogs.FolderBrowser
     [TestFixture]
     public class FolderBrowserDialogSettingsSyncTest
     {
-        private FolderBrowserDialog dialog;
-        private FolderBrowserDialogSettings settings;
-        private FolderBrowserDialogSettingsSync sync;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialog = new FolderBrowserDialog();
-            settings = new FolderBrowserDialogSettings();
-            sync = new FolderBrowserDialogSettingsSync(dialog, settings);
-        }
-
         [Test]
         public void ToDialog()
         {
             // Arrange
+            var dialog = new FolderBrowserDialog();
+            var settings = new FolderBrowserDialogSettings();
+            var sync = new FolderBrowserDialogSettingsSync(dialog, settings);
+
             settings.Description = "Some description";
             settings.RootFolder = Environment.SpecialFolder.ProgramFiles;
             settings.SelectedPath = @"C:\temp";
@@ -42,6 +34,10 @@ namespace MvvmDialogs.FrameworkDialogs.FolderBrowser
         public void ToSettings()
         {
             // Arrange
+            var dialog = new FolderBrowserDialog();
+            var settings = new FolderBrowserDialogSettings();
+            var sync = new FolderBrowserDialogSettingsSync(dialog, settings);
+
             dialog.SelectedPath = @"C:\temp";
 
             // Act

--- a/test/net/FrameworkDialogs/MessageBox/MessageBoxWrapperTest.cs
+++ b/test/net/FrameworkDialogs/MessageBox/MessageBoxWrapperTest.cs
@@ -8,23 +8,15 @@ namespace MvvmDialogs.FrameworkDialogs.MessageBox
     [TestFixture]
     public class MessageBoxWrapperTest
     {
-        private MessageBoxSettings settings;
-        private Mock<IMessageBoxShow> messageBoxShow;
-        private MessageBoxWrapper dialog;
-
-        [SetUp]
-        public void SetUp()
-        {
-            settings = new MessageBoxSettings();
-            messageBoxShow = new Mock<IMessageBoxShow>();
-            dialog = new MessageBoxWrapper(messageBoxShow.Object, settings);
-        }
-
         [Test]
         [RequiresThread(ApartmentState.STA)]
         public void Show()
         {
             // Arrange
+            var settings = new MessageBoxSettings();
+            var messageBoxShow = new Mock<IMessageBoxShow>();
+            var dialog = new MessageBoxWrapper(messageBoxShow.Object, settings);
+
             settings.Button = MessageBoxButton.YesNoCancel;
             settings.Caption = "Some caption";
             settings.DefaultResult = MessageBoxResult.Yes;

--- a/test/net/FrameworkDialogs/OpenFile/OpenFileDialogSettingsSyncTest.cs
+++ b/test/net/FrameworkDialogs/OpenFile/OpenFileDialogSettingsSyncTest.cs
@@ -8,22 +8,14 @@ namespace MvvmDialogs.FrameworkDialogs.OpenFile
     [TestFixture]
     public class OpenFileDialogSettingsSyncTest
     {
-        private OpenFileDialog dialog;
-        private OpenFileDialogSettings settings;
-        private OpenFileDialogSettingsSync sync;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialog = new OpenFileDialog();
-            settings = new OpenFileDialogSettings();
-            sync = new OpenFileDialogSettingsSync(dialog, settings);
-        }
-
         [Test]
         public void ToDialog()
         {
             // Arrange
+            var dialog = new OpenFileDialog();
+            var settings = new OpenFileDialogSettings();
+            var sync = new OpenFileDialogSettingsSync(dialog, settings);
+
             settings.AddExtension = !settings.AddExtension;
             settings.CheckFileExists = !settings.CheckFileExists;
             settings.CheckPathExists = !settings.CheckPathExists;
@@ -71,6 +63,10 @@ namespace MvvmDialogs.FrameworkDialogs.OpenFile
         public void ToSettings()
         {
             // Arrange
+            var dialog = new OpenFileDialog();
+            var settings = new OpenFileDialogSettings();
+            var sync = new OpenFileDialogSettingsSync(dialog, settings);
+
             dialog.FileName = "SomeFile.txt";
             dialog.FilterIndex = 2;
 

--- a/test/net/FrameworkDialogs/SaveFile/SaveFileDialogSettingsSyncTest.cs
+++ b/test/net/FrameworkDialogs/SaveFile/SaveFileDialogSettingsSyncTest.cs
@@ -8,22 +8,14 @@ namespace MvvmDialogs.FrameworkDialogs.SaveFile
     [TestFixture]
     public class SaveFileDialogSettingsSyncTest
     {
-        private SaveFileDialog dialog;
-        private SaveFileDialogSettings settings;
-        private SaveFileDialogSettingsSync sync;
-
-        [SetUp]
-        public void SetUp()
-        {
-            dialog = new SaveFileDialog();
-            settings = new SaveFileDialogSettings();
-            sync = new SaveFileDialogSettingsSync(dialog, settings);
-        }
-
         [Test]
         public void ToDialog()
         {
             // Arrange
+            var dialog = new SaveFileDialog();
+            var settings = new SaveFileDialogSettings();
+            var sync = new SaveFileDialogSettingsSync(dialog, settings);
+
             settings.AddExtension = !settings.AddExtension;
             settings.CheckFileExists = !settings.CheckFileExists;
             settings.CheckPathExists = !settings.CheckPathExists;
@@ -69,6 +61,10 @@ namespace MvvmDialogs.FrameworkDialogs.SaveFile
         public void ToSettings()
         {
             // Arrange
+            var dialog = new SaveFileDialog();
+            var settings = new SaveFileDialogSettings();
+            var sync = new SaveFileDialogSettingsSync(dialog, settings);
+
             dialog.FileName = "SomeFile.txt";
             dialog.FilterIndex = 2;
 

--- a/test/net/MvvmDialogs.Test.csproj
+++ b/test/net/MvvmDialogs.Test.csproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net472</TargetFramework>
     <RootNamespace>MvvmDialogs</RootNamespace>
+    <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\StrongName.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/test/net/TestAssemblyBuilder.cs
+++ b/test/net/TestAssemblyBuilder.cs
@@ -23,7 +23,7 @@ namespace MvvmDialogs
                 FileName);
         }
 
-        public Type CreateType(string fullName, Type parenType = null)
+        public Type CreateType(string fullName, Type? parenType = null)
         {
             TypeBuilder typeBuilder = moduleBuilder.DefineType(
                 fullName,

--- a/test/net/ViewModelBase.cs
+++ b/test/net/ViewModelBase.cs
@@ -4,7 +4,7 @@ namespace MvvmDialogs
 {
     public abstract class ViewModelBase : INotifyPropertyChanged
     {
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         protected void RaisePropertyChanged(PropertyChangedEventArgs e)
         {

--- a/test/net/Views/ViewWrapperTest.cs
+++ b/test/net/Views/ViewWrapperTest.cs
@@ -8,18 +8,11 @@ namespace MvvmDialogs.Views
     [Apartment(ApartmentState.STA)]
     public class ViewWrapperTest
     {
-        private FrameworkElement frameworkElement;
-
-        [SetUp]
-        public void SetUp()
-        {
-            frameworkElement = new FrameworkElement();
-        }
-
         [Test]
         public void Source()
         {
             // Arrange
+            var frameworkElement = new FrameworkElement();
             var viewWrapper = new ViewWrapper(frameworkElement);
 
             // Assert
@@ -30,6 +23,8 @@ namespace MvvmDialogs.Views
         public void GetHashCodeOverride()
         {
             // Arrange
+            var frameworkElement = new FrameworkElement();
+
             var viewWrapperA = new ViewWrapper(frameworkElement);
             var viewWrapperB = new ViewWrapper(frameworkElement);
 
@@ -45,6 +40,8 @@ namespace MvvmDialogs.Views
         public void EqualsOverride()
         {
             // Arrange
+            var frameworkElement = new FrameworkElement();
+
             var viewWrapperA = new ViewWrapper(frameworkElement);
             var viewWrapperB = new ViewWrapper(frameworkElement);
 


### PR DESCRIPTION
Enable [nullable types](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references) on project level. UWP projects are not affected since `Nullable` doesn't work on old-styled cs-projects.