### PR TITLE
Migrate .NET versions

### DIFF
--- a/MvvmDialogs.nuspec
+++ b/MvvmDialogs.nuspec
@@ -15,16 +15,16 @@
     <releaseNotes>For release notes, please see the change log on GitHub.</releaseNotes>
     <tags>wpf uwp mvvm dialog window messagebox openfiledialog savefiledialog folderbrowserdialog messagedialog contentdialog fileopenpicker filesavepicker folderpicker</tags>
     <dependencies>
-      <group targetFramework=".NETFramework4.6.1" />
+      <group targetFramework=".NETFramework4.6.2" />
       <group targetFramework=".NETCoreApp3.1" />
       <group targetFramework="net5.0-windows7.0" />
     </dependencies>
   </metadata>
   <files>
     <!-- .NET Framework -->
-    <file src="src\bin\Release\net461\MvvmDialogs.dll" target="lib\net461\MvvmDialogs.dll" />
-    <file src="src\bin\Release\net461\MvvmDialogs.xml" target="lib\net461\MvvmDialogs.xml" />
-    <file src="src\bin\Release\net461\MvvmDialogs.pdb" target="lib\net461\MvvmDialogs.pdb" />
+    <file src="src\bin\Release\net462\MvvmDialogs.dll" target="lib\net462\MvvmDialogs.dll" />
+    <file src="src\bin\Release\net462\MvvmDialogs.xml" target="lib\net462\MvvmDialogs.xml" />
+    <file src="src\bin\Release\net462\MvvmDialogs.pdb" target="lib\net462\MvvmDialogs.pdb" />
 
     <!-- .NET Core -->
     <file src="src\bin\Release\netcoreapp3.1\MvvmDialogs.dll" target="lib\netcoreapp3.1\MvvmDialogs.dll" />

--- a/src/MvvmDialogs.csproj
+++ b/src/MvvmDialogs.csproj
@@ -7,7 +7,7 @@
       Lets have the .NET Framework version listed first, otherwise we will get build warnings in Visual Studio.
       See https://github.com/dotnet/project-system/issues/1162 for more information.
      -->
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <AssemblyTitle>MVVM Dialogs</AssemblyTitle>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
# Description

.NET 4.6.1 is no longer supported.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
