### PR TITLE
Remove support for .NET Core 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 - [BREAKING CHANGE] Support for .NET Framework 3.5
 - [BREAKING CHANGE] Support for .NET Framework 4.0 and .NET Framework 4.5 due to [deprecation as of January 12, 2016](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework)
 - [BREAKING CHANGE] Support for .NET Framework 4.5.2 due to [deprecation as of April 26, 2022](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework)
+- [BREAKING CHANGE] Support for .NET Core 3.1 in preparation for [deprecation December 13, 2022](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core)
 - [BREAKING CHANGE] Support for UWP due to problematic support in VS2022
 
 ## 8.0.0 - 2020-11-19

--- a/MvvmDialogs.nuspec
+++ b/MvvmDialogs.nuspec
@@ -16,7 +16,6 @@
     <tags>wpf uwp mvvm dialog window messagebox openfiledialog savefiledialog folderbrowserdialog messagedialog contentdialog fileopenpicker filesavepicker folderpicker</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.6.2" />
-      <group targetFramework=".NETCoreApp3.1" />
       <group targetFramework="net5.0-windows7.0" />
     </dependencies>
   </metadata>
@@ -27,9 +26,6 @@
     <file src="src\bin\Release\net462\MvvmDialogs.pdb" target="lib\net462\MvvmDialogs.pdb" />
 
     <!-- .NET Core -->
-    <file src="src\bin\Release\netcoreapp3.1\MvvmDialogs.dll" target="lib\netcoreapp3.1\MvvmDialogs.dll" />
-    <file src="src\bin\Release\netcoreapp3.1\MvvmDialogs.xml" target="lib\netcoreapp3.1\MvvmDialogs.xml" />
-    <file src="src\bin\Release\netcoreapp3.1\MvvmDialogs.pdb" target="lib\netcoreapp3.1\MvvmDialogs.pdb" />
     <file src="src\bin\Release\net5.0-windows\MvvmDialogs.dll" target="lib\net5.0-windows7.0\MvvmDialogs.dll" />
     <file src="src\bin\Release\net5.0-windows\MvvmDialogs.xml" target="lib\net5.0-windows7.0\MvvmDialogs.xml" />
     <file src="src\bin\Release\net5.0-windows\MvvmDialogs.pdb" target="lib\net5.0-windows7.0\MvvmDialogs.pdb" />

--- a/samples/Demo.ActivateNonModalDialog/Demo.ActivateNonModalDialog.csproj
+++ b/samples/Demo.ActivateNonModalDialog/Demo.ActivateNonModalDialog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.ActivateNonModalDialog</RootNamespace>
     <AssemblyName>Demo.ActivateNonModalDialog</AssemblyName>

--- a/samples/Demo.CloseNonModalDialog/Demo.CloseNonModalDialog.csproj
+++ b/samples/Demo.CloseNonModalDialog/Demo.CloseNonModalDialog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CloseNonModalDialog</RootNamespace>
     <AssemblyName>Demo.CloseNonModalDialog</AssemblyName>

--- a/samples/Demo.CustomDialogTypeLocator/Demo.CustomDialogTypeLocator.csproj
+++ b/samples/Demo.CustomDialogTypeLocator/Demo.CustomDialogTypeLocator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CustomDialogTypeLocator</RootNamespace>
     <AssemblyName>Demo.CustomDialogTypeLocator</AssemblyName>

--- a/samples/Demo.CustomFolderBrowserDialog/Demo.CustomFolderBrowserDialog.csproj
+++ b/samples/Demo.CustomFolderBrowserDialog/Demo.CustomFolderBrowserDialog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CustomFolderBrowserDialog</RootNamespace>
     <AssemblyName>Demo.CustomFolderBrowserDialog</AssemblyName>

--- a/samples/Demo.CustomMessageBox/Demo.CustomMessageBox.csproj
+++ b/samples/Demo.CustomMessageBox/Demo.CustomMessageBox.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CustomMessageBox</RootNamespace>
     <AssemblyName>Demo.CustomMessageBox</AssemblyName>

--- a/samples/Demo.CustomOpenFileDialog/Demo.CustomOpenFileDialog.csproj
+++ b/samples/Demo.CustomOpenFileDialog/Demo.CustomOpenFileDialog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CustomOpenFileDialog</RootNamespace>
     <AssemblyName>Demo.CustomOpenFileDialog</AssemblyName>

--- a/samples/Demo.CustomSaveFileDialog/Demo.CustomSaveFileDialog.csproj
+++ b/samples/Demo.CustomSaveFileDialog/Demo.CustomSaveFileDialog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.CustomSaveFileDialog</RootNamespace>
     <AssemblyName>Demo.CustomSaveFileDialog</AssemblyName>

--- a/samples/Demo.FolderBrowserDialog/Demo.FolderBrowserDialog.csproj
+++ b/samples/Demo.FolderBrowserDialog/Demo.FolderBrowserDialog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.FolderBrowserDialog</RootNamespace>
     <AssemblyName>Demo.FolderBrowserDialog</AssemblyName>

--- a/samples/Demo.MessageBox/Demo.MessageBox.csproj
+++ b/samples/Demo.MessageBox/Demo.MessageBox.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.MessageBox</RootNamespace>
     <AssemblyName>Demo.MessageBox</AssemblyName>

--- a/samples/Demo.ModalCustomDialog/Demo.ModalCustomDialog.csproj
+++ b/samples/Demo.ModalCustomDialog/Demo.ModalCustomDialog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.ModalCustomDialog</RootNamespace>
     <AssemblyName>Demo.ModalCustomDialog</AssemblyName>

--- a/samples/Demo.ModalDialog/Demo.ModalDialog.csproj
+++ b/samples/Demo.ModalDialog/Demo.ModalDialog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.ModalDialog</RootNamespace>
     <AssemblyName>Demo.ModalDialog</AssemblyName>

--- a/samples/Demo.NonModalCustomDialog/Demo.NonModalCustomDialog.csproj
+++ b/samples/Demo.NonModalCustomDialog/Demo.NonModalCustomDialog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.NonModalCustomDialog</RootNamespace>
     <AssemblyName>Demo.NonModalCustomDialog</AssemblyName>

--- a/samples/Demo.NonModalDialog/Demo.NonModalDialog.csproj
+++ b/samples/Demo.NonModalDialog/Demo.NonModalDialog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.NonModalDialog</RootNamespace>
     <AssemblyName>Demo.NonModalDialog</AssemblyName>

--- a/samples/Demo.OpenFileDialog/Demo.OpenFileDialog.csproj
+++ b/samples/Demo.OpenFileDialog/Demo.OpenFileDialog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.OpenFileDialog</RootNamespace>
     <AssemblyName>Demo.OpenFileDialog</AssemblyName>

--- a/samples/Demo.SaveFileDialog/Demo.SaveFileDialog.csproj
+++ b/samples/Demo.SaveFileDialog/Demo.SaveFileDialog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Demo.SaveFileDialog</RootNamespace>
     <AssemblyName>Demo.SaveFileDialog</AssemblyName>

--- a/src/MvvmDialogs.csproj
+++ b/src/MvvmDialogs.csproj
@@ -7,7 +7,7 @@
       Lets have the .NET Framework version listed first, otherwise we will get build warnings in Visual Studio.
       See https://github.com/dotnet/project-system/issues/1162 for more information.
      -->
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
     <AssemblyTitle>MVVM Dialogs</AssemblyTitle>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
# Description

Remove support for .NET Core 3.1 in preparation for [deprecation December 13, 2022](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
