### PR TITLE
Allow Overriding FindOwnerWindow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ### :zap: Added
 
-- [#221](https://github.com/FantasticFiasco/mvvm-dialogs/pull/221) `DialogService.FindOwnerWindow`, a method that finds the window corresponding to specified a view model, has been promoted to `protected virtual` (contributed by [@RFBomb](https://github.com/RFBomb))
+- [#221](https://github.com/FantasticFiasco/mvvm-dialogs/pull/221) `DialogService.FindOwnerWindow`, a method that finds the window corresponding to specified a view model, has been added as `protected virtual`, allowing you to override its behavior (contributed by [@RFBomb](https://github.com/RFBomb))
 
 ## 9.0.1 - 2022-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ## Unreleased
 
+### :zap: Added
+
+- [#221](https://github.com/FantasticFiasco/mvvm-dialogs/pull/221) `DialogService.FindOwnerWindow`, a method that finds the window corresponding to specified a view model, has been promoted to `protected virtual` (contributed by [@RFBomb](https://github.com/RFBomb))
+
 ## 9.0.1 - 2022-08-27
 
 ### :syringe: Fixed

--- a/src/DialogService.cs
+++ b/src/DialogService.cs
@@ -305,6 +305,16 @@ namespace MvvmDialogs
             return dialog;
         }
 
+        /// <summary>
+        /// Finds window corresponding to specified view model.
+        /// </summary>
+        /// <exception cref="ViewNotRegisteredException"/>
+        /// <exception cref="InvalidOperationException"/>
+        protected virtual Window FindOwnerWindow(INotifyPropertyChanged viewModel)
+        {
+            DialogService.FindOwner(viewModel);
+        }
+
         private static PropertyChangedEventHandler RegisterDialogResult(
             IWindow dialog,
             IModalDialogViewModel viewModel)
@@ -331,7 +341,9 @@ namespace MvvmDialogs
         /// <summary>
         /// Finds window corresponding to specified view model.
         /// </summary>
-        private static Window FindOwnerWindow(INotifyPropertyChanged viewModel)
+        /// <exception cref="ViewNotRegisteredException"/>
+        /// <exception cref="InvalidOperationException"/>
+        private static Window FindOwner(INotifyPropertyChanged viewModel)
         {
             IView? view = DialogServiceViews.Views.SingleOrDefault(
                 registeredView =>

--- a/src/DialogService.cs
+++ b/src/DialogService.cs
@@ -312,7 +312,7 @@ namespace MvvmDialogs
         /// <exception cref="InvalidOperationException"/>
         protected virtual Window FindOwnerWindow(INotifyPropertyChanged viewModel)
         {
-            DialogService.FindOwner(viewModel);
+            return DialogService.FindOwner(viewModel);
         }
 
         private static PropertyChangedEventHandler RegisterDialogResult(


### PR DESCRIPTION
# Description

Rename the static `FindOwnerWindow` method to `FindOwner` and introduce a protected virtual `FindOwnerWindow` method. 

- Fixes #(issue)

Currently, most of the service action can be modified by introducing different factories for the type locators or dialog factories. The exception to this rule is locating the owner window. This change fixes that. 

In my application, I have many custom controls that are a combination of other controls. (For example, a control that houses around 10 comboboxes, about 6 buttons, a listbox, etc). This is controlled by what I deemed a 'ControlModel'. The 'ControlModel' has a property called 'Parent' which points to its parent ViewModel. 

The tricky thing here is that the 'Parent' may not be on the registered view, the Parent's Parent may be though. So what I want to do is traverse up the 'Parent-Tree' until I find the registered view. Currently, this library does not allow for that. 

So this PR exposes the method of finding the parent window and allows overriding just that functionality if needed. I figured this would be fine since the DialogService class is not sealed.

My usage would look something like this:

```
protected override Window FindOwnerWindow(INotifyPropertyChanged viewModel)
{
    if (viewModel is IViewModel vm)
    {
        try
        {
            return base.FindOwnerWindow(viewModel);
        }
        catch (ViewNotRegisteredException) when vm.ParentViewModel != null
        {
            return FindOwnerWindow(vm.ParentViewModel); // Recurse up the ParentViewModels until the registered view is found
        }
    } else
        return base.FindOwnerWindow(viewModel);        
}
```

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
