### PR TITLE
Made IView Interface and ViewWrapper class public, Exposed Logger.Write Method (#263)

### DIFF
--- a/src/Logging/Logger.cs
+++ b/src/Logging/Logger.cs
@@ -30,7 +30,14 @@ public static class Logger
         set => writer = value ?? throw new ArgumentNullException(nameof(value));
     }
 
-    internal static void Write(
+    /// <summary>
+    /// Writes message to <see cref="Logger.Writer"/>.
+    /// </summary>
+    /// <param name="message">Message to log.</param>
+    /// <param name="callerFilePath">Calling file path.</param>
+    /// <param name="callerMemberName">Calling member name.</param>
+    /// <exception cref="ArgumentNullException" />
+    public static void Write(
         string message,
         [CallerFilePath] string callerFilePath = "",
         [CallerMemberName] string callerMemberName = "")

--- a/src/Views/IView.cs
+++ b/src/Views/IView.cs
@@ -5,7 +5,7 @@ namespace MvvmDialogs.Views;
 /// <summary>
 /// Interface describing a view in WPF.
 /// </summary>
-internal interface IView
+public interface IView
 {
     /// <summary>
     /// Occurs when the view is laid out, rendered, and ready for interaction.

--- a/src/Views/ViewWrapper.cs
+++ b/src/Views/ViewWrapper.cs
@@ -3,25 +3,40 @@ using System.Windows;
 
 namespace MvvmDialogs.Views;
 
-internal class ViewWrapper : IView
+/// <summary>
+/// Wraps <see cref="FrameworkElement"/> objects for the properties needed.
+/// </summary>
+public class ViewWrapper : IView
 {
     private readonly WeakReference viewReference;
 
-    internal ViewWrapper(FrameworkElement view)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ViewWrapper"/> class.
+    /// </summary>
+    /// <param name="view"><see cref="FrameworkElement"/> that makes up the view.</param>
+    /// <exception cref="ArgumentNullException" />
+    public ViewWrapper(FrameworkElement view)
     {
         if (view == null) throw new ArgumentNullException(nameof(view));
 
         viewReference = new WeakReference(view);
     }
 
+
+    /// <inheritdoc />
     public event RoutedEventHandler Loaded
     {
         add => Source.Loaded += value;
         remove => Source.Loaded -= value;
     }
 
+
+    /// <inheritdoc />
     public int Id { get; } = IdGenerator.Generate();
 
+
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException" />
     public FrameworkElement Source
     {
         get
@@ -33,14 +48,29 @@ internal class ViewWrapper : IView
         }
     }
 
+    /// <inheritdoc />
     public object DataContext => Source.DataContext;
 
+    /// <inheritdoc />
     public bool IsAlive => viewReference.IsAlive;
 
+
+    /// <inheritdoc />
     public Window GetOwner() => Source.GetOwner();
 
+
+    /// <summary>
+    /// GetHashCode override based on the Source property
+    /// </summary>
+    /// <returns>HashCode of Source property</returns>
     public override int GetHashCode() => Source.GetHashCode();
 
+
+    /// <summary>
+    /// Equals Override comparing the Source property
+    /// </summary>
+    /// <param name="obj">Object of type <see cref="ViewWrapper"/></param>
+    /// <returns>True if the object is the same</returns>
     public override bool Equals(object? obj)
     {
         if (!(obj is ViewWrapper other))


### PR DESCRIPTION
# Description

Made the MvvmDialogs library extendable to that people could implement their own `DialogServiceViews`-like class and `DialogService` class that utilizes that collection of registered views. This allows for people to use a thread-safe collection when running an application with multiple UI threads.

- Fixes #263 

# Checklist

- [✔] My code follows the style guidelines of this project
- [✔] I have performed a self-review of my own code
- [✔] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
